### PR TITLE
Add Phase 3: ASR integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "asr-core",
  "cpal",
  "ringbuf",
+ "tokio",
  "tracing",
 ]
 
@@ -117,6 +118,14 @@ version = "0.1.0"
 [[package]]
 name = "asr-engine"
 version = "0.1.0"
+dependencies = [
+ "asr-core",
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+]
 
 [[package]]
 name = "asr-mixing-router"
@@ -125,8 +134,10 @@ dependencies = [
  "anyhow",
  "asr-audio",
  "asr-core",
+ "asr-engine",
  "clap",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -138,6 +149,17 @@ version = "0.1.0"
 [[package]]
 name = "asr-tui"
 version = "0.1.0"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,10 @@ edition = "2021"
 [dependencies]
 asr-core = { workspace = true }
 asr-audio = { workspace = true }
+asr-engine = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+toml = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/asr-audio/Cargo.toml
+++ b/crates/asr-audio/Cargo.toml
@@ -8,3 +8,4 @@ asr-core = { workspace = true }
 cpal = { workspace = true }
 ringbuf = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }

--- a/crates/asr-audio/src/capture.rs
+++ b/crates/asr-audio/src/capture.rs
@@ -1,9 +1,10 @@
-use asr_core::AudioError;
+use asr_core::{AudioChunk, AudioError};
 use cpal::traits::DeviceTrait;
 use cpal::{Device, SampleRate, Stream, StreamConfig};
 use ringbuf::traits::Producer;
 use ringbuf::HeapProd;
 use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
 
 pub struct CaptureNode {
     _stream: Stream,
@@ -16,6 +17,7 @@ impl CaptureNode {
         sample_rate: u32,
         channels: u16,
         buffer_size: u32,
+        asr_tap: Option<mpsc::UnboundedSender<AudioChunk>>,
     ) -> Result<Self, AudioError> {
         let config = StreamConfig {
             channels,
@@ -37,6 +39,14 @@ impl CaptureNode {
                         // Push as much as we can; overflow is silently dropped
                         prod.push_slice(data);
                     }
+                    if let Some(ref tap) = asr_tap {
+                        let chunk = AudioChunk {
+                            samples: data.to_vec(),
+                            sample_rate,
+                            channels,
+                        };
+                        let _ = tap.send(chunk);
+                    }
                 },
                 err_callback,
                 None,
@@ -44,5 +54,55 @@ impl CaptureNode {
             .map_err(|e| AudioError::StreamBuild(e.to_string()))?;
 
         Ok(Self { _stream: stream })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use asr_core::AudioChunk;
+    use tokio::sync::mpsc;
+
+    #[test]
+    fn test_asr_tap_send_receives_chunk() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<AudioChunk>();
+        let chunk = AudioChunk {
+            samples: vec![0.1, 0.2, 0.3],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        tx.send(chunk).unwrap();
+
+        let received = rx.try_recv().unwrap();
+        assert_eq!(received.samples, vec![0.1, 0.2, 0.3]);
+        assert_eq!(received.sample_rate, 48000);
+        assert_eq!(received.channels, 1);
+    }
+
+    #[test]
+    fn test_asr_tap_none_does_not_panic() {
+        let tap: Option<mpsc::UnboundedSender<AudioChunk>> = None;
+        // Simulating the callback logic
+        if let Some(ref tx) = tap {
+            let chunk = AudioChunk {
+                samples: vec![0.0],
+                sample_rate: 48000,
+                channels: 1,
+            };
+            let _ = tx.send(chunk);
+        }
+        // No panic — test passes
+    }
+
+    #[test]
+    fn test_asr_tap_dropped_receiver_does_not_panic() {
+        let (tx, rx) = mpsc::unbounded_channel::<AudioChunk>();
+        drop(rx);
+        let chunk = AudioChunk {
+            samples: vec![0.0; 480],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        // `let _ = tx.send(...)` should not panic even with a dropped receiver
+        let _ = tx.send(chunk);
     }
 }

--- a/crates/asr-core/src/config.rs
+++ b/crates/asr-core/src/config.rs
@@ -1,6 +1,6 @@
 use crate::error::ConfigError;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -100,7 +100,7 @@ pub struct AsrConfig {
     pub whisper: Option<WhisperConfig>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct WhisperConfig {
     pub model_path: String,
 

--- a/crates/asr-engine/Cargo.toml
+++ b/crates/asr-engine/Cargo.toml
@@ -4,3 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+asr-core = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+toml = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+default = []
+whisper = []
+
+# When real whisper inference is needed, uncomment:
+# whisper = ["dep:whisper-rs"]
+# [dependencies.whisper-rs]
+# version = "0.12"
+# optional = true

--- a/crates/asr-engine/src/engine_trait.rs
+++ b/crates/asr-engine/src/engine_trait.rs
@@ -1,0 +1,12 @@
+use asr_core::{AsrError, AudioChunk, RecognitionResult};
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+#[async_trait]
+pub trait AsrEngine: Send + Sync {
+    fn name(&self) -> &str;
+    async fn initialize(&mut self, config: toml::Value) -> Result<(), AsrError>;
+    async fn feed_audio(&self, chunk: AudioChunk) -> Result<(), AsrError>;
+    fn set_result_sender(&mut self, sender: mpsc::UnboundedSender<RecognitionResult>);
+    async fn shutdown(&self) -> Result<(), AsrError>;
+}

--- a/crates/asr-engine/src/host.rs
+++ b/crates/asr-engine/src/host.rs
@@ -1,0 +1,306 @@
+use crate::engine_trait::AsrEngine;
+use crate::registry::PluginRegistry;
+use asr_core::{AsrError, AudioChunk, RecognitionResult};
+use tokio::sync::mpsc;
+
+struct PendingInput {
+    id: String,
+    engine: Box<dyn AsrEngine>,
+    tap_rx: mpsc::UnboundedReceiver<AudioChunk>,
+    engine_result_rx: mpsc::UnboundedReceiver<RecognitionResult>,
+}
+
+pub struct AsrHost {
+    inputs: Vec<PendingInput>,
+    result_tx: mpsc::UnboundedSender<RecognitionResult>,
+    result_rx: Option<mpsc::UnboundedReceiver<RecognitionResult>>,
+    task_handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl AsrHost {
+    pub fn new() -> Self {
+        let (result_tx, result_rx) = mpsc::unbounded_channel();
+        Self {
+            inputs: Vec::new(),
+            result_tx,
+            result_rx: Some(result_rx),
+            task_handles: Vec::new(),
+        }
+    }
+
+    pub fn take_result_receiver(&mut self) -> Option<mpsc::UnboundedReceiver<RecognitionResult>> {
+        self.result_rx.take()
+    }
+
+    pub async fn add_input(
+        &mut self,
+        id: &str,
+        engine_name: &str,
+        config: toml::Value,
+        registry: &PluginRegistry,
+    ) -> Result<mpsc::UnboundedSender<AudioChunk>, AsrError> {
+        let mut engine = registry.create(engine_name)?;
+
+        // Create per-engine result channel
+        let (engine_result_tx, engine_result_rx) = mpsc::unbounded_channel();
+        engine.set_result_sender(engine_result_tx);
+        engine.initialize(config).await?;
+
+        // Create tap channel for audio input
+        let (tap_tx, tap_rx) = mpsc::unbounded_channel();
+
+        self.inputs.push(PendingInput {
+            id: id.to_string(),
+            engine,
+            tap_rx,
+            engine_result_rx,
+        });
+
+        Ok(tap_tx)
+    }
+
+    pub fn start(&mut self) {
+        let inputs = std::mem::take(&mut self.inputs);
+        for input in inputs {
+            let input_id = input.id;
+            let engine = input.engine;
+            let mut tap_rx = input.tap_rx;
+            let mut engine_result_rx = input.engine_result_rx;
+            let shared_tx = self.result_tx.clone();
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        chunk = tap_rx.recv() => {
+                            match chunk {
+                                Some(audio) => {
+                                    if let Err(e) = engine.feed_audio(audio).await {
+                                        tracing::error!(
+                                            input_id = %input_id,
+                                            "engine feed error: {e}"
+                                        );
+                                    }
+                                }
+                                None => {
+                                    // Tap sender dropped — shut down this input
+                                    tracing::debug!(
+                                        input_id = %input_id,
+                                        "tap sender dropped, shutting down"
+                                    );
+                                    let _ = engine.shutdown().await;
+                                    break;
+                                }
+                            }
+                        }
+                        result = engine_result_rx.recv() => {
+                            match result {
+                                Some(mut r) => {
+                                    r.input_id = input_id.clone();
+                                    let _ = shared_tx.send(r);
+                                }
+                                None => {
+                                    // Engine result channel closed
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            self.task_handles.push(handle);
+        }
+    }
+
+    pub async fn shutdown(&mut self) {
+        let handles = std::mem::take(&mut self.task_handles);
+        for handle in handles {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Default for AsrHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_registry() -> PluginRegistry {
+        PluginRegistry::new()
+    }
+
+    #[tokio::test]
+    async fn test_host_new_has_result_receiver() {
+        let mut host = AsrHost::new();
+        assert!(host.take_result_receiver().is_some());
+        assert!(host.take_result_receiver().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_host_add_input_returns_tap_sender() {
+        let mut host = AsrHost::new();
+        let registry = test_registry();
+        let tx = host
+            .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+            .await
+            .unwrap();
+        // Sending should not panic
+        let chunk = AudioChunk {
+            samples: vec![0.0; 480],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        tx.send(chunk).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_host_add_input_unknown_engine_fails() {
+        let mut host = AsrHost::new();
+        let registry = test_registry();
+        let result = host
+            .add_input("mic1", "nonexistent", toml::Value::Table(Default::default()), &registry)
+            .await;
+        match result {
+            Err(AsrError::EngineNotFound(_)) => {}
+            _ => panic!("expected EngineNotFound"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_host_start_and_feed_produces_result() {
+        let mut host = AsrHost::new();
+        let registry = test_registry();
+        let mut rx = host.take_result_receiver().unwrap();
+
+        let tx = host
+            .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+            .await
+            .unwrap();
+        host.start();
+
+        let chunk = AudioChunk {
+            samples: vec![0.0; 480],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        tx.send(chunk).unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timed out")
+            .expect("channel closed");
+        assert!(result.text.contains("480"));
+    }
+
+    #[tokio::test]
+    async fn test_host_multiple_inputs_produce_results() {
+        let mut host = AsrHost::new();
+        let registry = test_registry();
+        let mut rx = host.take_result_receiver().unwrap();
+
+        let tx1 = host
+            .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+            .await
+            .unwrap();
+        let tx2 = host
+            .add_input("mic2", "null", toml::Value::Table(Default::default()), &registry)
+            .await
+            .unwrap();
+        host.start();
+
+        let chunk1 = AudioChunk {
+            samples: vec![0.0; 100],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        let chunk2 = AudioChunk {
+            samples: vec![0.0; 200],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        tx1.send(chunk1).unwrap();
+        tx2.send(chunk2).unwrap();
+
+        let timeout = std::time::Duration::from_secs(2);
+        let r1 = tokio::time::timeout(timeout, rx.recv())
+            .await
+            .expect("timed out")
+            .expect("closed");
+        let r2 = tokio::time::timeout(timeout, rx.recv())
+            .await
+            .expect("timed out")
+            .expect("closed");
+
+        let mut ids: Vec<_> = vec![r1.input_id.clone(), r2.input_id.clone()];
+        ids.sort();
+        assert_eq!(ids, vec!["mic1", "mic2"]);
+    }
+
+    #[tokio::test]
+    async fn test_host_drop_tap_sender_stops_task() {
+        let mut host = AsrHost::new();
+        let registry = test_registry();
+
+        let tx = host
+            .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+            .await
+            .unwrap();
+        host.start();
+
+        drop(tx);
+
+        // Shutdown should complete without hanging
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+    }
+
+    #[tokio::test]
+    async fn test_host_shutdown_awaits_tasks() {
+        let mut host = AsrHost::new();
+        let registry = test_registry();
+
+        let tx = host
+            .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+            .await
+            .unwrap();
+        host.start();
+
+        drop(tx);
+
+        // Should not hang
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+    }
+
+    #[tokio::test]
+    async fn test_host_result_contains_input_id() {
+        let mut host = AsrHost::new();
+        let registry = test_registry();
+        let mut rx = host.take_result_receiver().unwrap();
+
+        let tx = host
+            .add_input("radio1", "null", toml::Value::Table(Default::default()), &registry)
+            .await
+            .unwrap();
+        host.start();
+
+        let chunk = AudioChunk {
+            samples: vec![0.0; 480],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        tx.send(chunk).unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timed out")
+            .expect("closed");
+        assert_eq!(result.input_id, "radio1");
+    }
+}

--- a/crates/asr-engine/src/lib.rs
+++ b/crates/asr-engine/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod engine_trait;
+pub mod host;
+pub mod null_engine;
+pub mod registry;
+#[cfg(feature = "whisper")]
+pub mod whisper_engine;
+
+pub use engine_trait::AsrEngine;
+pub use host::AsrHost;
+pub use null_engine::NullEngine;
+pub use registry::PluginRegistry;
+#[cfg(feature = "whisper")]
+pub use whisper_engine::WhisperEngine;

--- a/crates/asr-engine/src/null_engine.rs
+++ b/crates/asr-engine/src/null_engine.rs
@@ -1,0 +1,160 @@
+use crate::engine_trait::AsrEngine;
+use asr_core::{AsrError, AudioChunk, RecognitionResult};
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use tokio::sync::mpsc;
+
+pub struct NullEngine {
+    feed_count: AtomicUsize,
+    result_sender: Mutex<Option<mpsc::UnboundedSender<RecognitionResult>>>,
+}
+
+impl NullEngine {
+    pub fn new() -> Self {
+        Self {
+            feed_count: AtomicUsize::new(0),
+            result_sender: Mutex::new(None),
+        }
+    }
+
+    pub fn feed_count(&self) -> usize {
+        self.feed_count.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for NullEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AsrEngine for NullEngine {
+    fn name(&self) -> &str {
+        "null"
+    }
+
+    async fn initialize(&mut self, _config: toml::Value) -> Result<(), AsrError> {
+        Ok(())
+    }
+
+    async fn feed_audio(&self, chunk: AudioChunk) -> Result<(), AsrError> {
+        let count = self.feed_count.fetch_add(1, Ordering::Relaxed) + 1;
+        let result = RecognitionResult {
+            text: format!("[null] {} samples", chunk.samples.len()),
+            input_id: String::new(),
+            timestamp: 0.0,
+            is_final: true,
+        };
+        if let Ok(sender) = self.result_sender.lock() {
+            if let Some(tx) = sender.as_ref() {
+                let _ = tx.send(result);
+            }
+        }
+        tracing::trace!("NullEngine fed chunk #{count}, {} samples", chunk.samples.len());
+        Ok(())
+    }
+
+    fn set_result_sender(&mut self, sender: mpsc::UnboundedSender<RecognitionResult>) {
+        *self.result_sender.lock().unwrap() = Some(sender);
+    }
+
+    async fn shutdown(&self) -> Result<(), AsrError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_null_engine_name() {
+        let engine = NullEngine::new();
+        assert_eq!(engine.name(), "null");
+    }
+
+    #[tokio::test]
+    async fn test_null_engine_initialize_succeeds() {
+        let mut engine = NullEngine::new();
+        let result = engine.initialize(toml::Value::Table(Default::default())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_null_engine_feed_audio_no_sender() {
+        let engine = NullEngine::new();
+        let chunk = AudioChunk {
+            samples: vec![0.0; 480],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        // Should not panic without a sender
+        let result = engine.feed_audio(chunk).await;
+        assert!(result.is_ok());
+        assert_eq!(engine.feed_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_null_engine_feed_audio_sends_result() {
+        let mut engine = NullEngine::new();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        engine.set_result_sender(tx);
+
+        let chunk = AudioChunk {
+            samples: vec![0.0; 480],
+            sample_rate: 48000,
+            channels: 1,
+        };
+        engine.feed_audio(chunk).await.unwrap();
+
+        let result = rx.recv().await.unwrap();
+        assert_eq!(result.text, "[null] 480 samples");
+    }
+
+    #[tokio::test]
+    async fn test_null_engine_result_has_correct_fields() {
+        let mut engine = NullEngine::new();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        engine.set_result_sender(tx);
+
+        let chunk = AudioChunk {
+            samples: vec![0.0; 100],
+            sample_rate: 16000,
+            channels: 1,
+        };
+        engine.feed_audio(chunk).await.unwrap();
+
+        let result = rx.recv().await.unwrap();
+        assert!(result.is_final);
+        assert!(!result.text.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_null_engine_feed_count_increments() {
+        let engine = NullEngine::new();
+        for _ in 0..3 {
+            let chunk = AudioChunk {
+                samples: vec![0.0; 480],
+                sample_rate: 48000,
+                channels: 1,
+            };
+            engine.feed_audio(chunk).await.unwrap();
+        }
+        assert_eq!(engine.feed_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_null_engine_shutdown_succeeds() {
+        let engine = NullEngine::new();
+        let result = engine.shutdown().await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_null_engine_implements_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<NullEngine>();
+    }
+}

--- a/crates/asr-engine/src/registry.rs
+++ b/crates/asr-engine/src/registry.rs
@@ -1,0 +1,97 @@
+use crate::engine_trait::AsrEngine;
+use asr_core::AsrError;
+use std::collections::HashMap;
+
+pub struct PluginRegistry {
+    factories: HashMap<String, fn() -> Box<dyn AsrEngine>>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            factories: HashMap::new(),
+        };
+        registry.register("null", || Box::new(crate::null_engine::NullEngine::new()));
+        #[cfg(feature = "whisper")]
+        registry.register("whisper", || {
+            Box::new(crate::whisper_engine::WhisperEngine::new())
+        });
+        registry
+    }
+
+    pub fn register(&mut self, name: &str, factory: fn() -> Box<dyn AsrEngine>) {
+        self.factories.insert(name.to_string(), factory);
+    }
+
+    pub fn create(&self, name: &str) -> Result<Box<dyn AsrEngine>, AsrError> {
+        self.factories
+            .get(name)
+            .map(|f| f())
+            .ok_or_else(|| AsrError::EngineNotFound(name.to_string()))
+    }
+
+    pub fn list_engines(&self) -> Vec<&str> {
+        self.factories.keys().map(|s| s.as_str()).collect()
+    }
+}
+
+impl Default for PluginRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NullEngine;
+
+    #[test]
+    fn test_registry_new_has_null_engine() {
+        let registry = PluginRegistry::new();
+        assert!(registry.create("null").is_ok());
+    }
+
+    #[test]
+    fn test_registry_create_null_returns_correct_name() {
+        let registry = PluginRegistry::new();
+        let engine = registry.create("null").unwrap();
+        assert_eq!(engine.name(), "null");
+    }
+
+    #[test]
+    fn test_registry_create_unknown_returns_error() {
+        let registry = PluginRegistry::new();
+        let result = registry.create("nope");
+        match result {
+            Err(AsrError::EngineNotFound(name)) => assert_eq!(name, "nope"),
+            _ => panic!("expected EngineNotFound error"),
+        }
+    }
+
+    #[test]
+    fn test_registry_register_custom_engine() {
+        let mut registry = PluginRegistry::new();
+        registry.register("custom", || Box::new(NullEngine::new()));
+        let engine = registry.create("custom").unwrap();
+        // NullEngine is used as the factory, so name is still "null"
+        assert_eq!(engine.name(), "null");
+    }
+
+    #[test]
+    fn test_registry_list_engines_includes_null() {
+        let registry = PluginRegistry::new();
+        let engines = registry.list_engines();
+        assert!(engines.contains(&"null"));
+    }
+
+    #[test]
+    fn test_registry_register_overwrites() {
+        let mut registry = PluginRegistry::new();
+        // Register a new factory under the same name
+        registry.register("null", || Box::new(NullEngine::new()));
+        // Should still work (overwritten with same factory type)
+        let engine = registry.create("null").unwrap();
+        assert_eq!(engine.name(), "null");
+    }
+}

--- a/crates/asr-engine/src/whisper_engine.rs
+++ b/crates/asr-engine/src/whisper_engine.rs
@@ -1,0 +1,115 @@
+use crate::engine_trait::AsrEngine;
+use asr_core::{AsrError, AudioChunk, RecognitionResult};
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+pub struct WhisperEngine {
+    model_path: Option<String>,
+    language: Option<String>,
+    result_sender: std::sync::Mutex<Option<mpsc::UnboundedSender<RecognitionResult>>>,
+}
+
+impl WhisperEngine {
+    pub fn new() -> Self {
+        Self {
+            model_path: None,
+            language: None,
+            result_sender: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl Default for WhisperEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AsrEngine for WhisperEngine {
+    fn name(&self) -> &str {
+        "whisper"
+    }
+
+    async fn initialize(&mut self, config: toml::Value) -> Result<(), AsrError> {
+        let model_path = config
+            .get("model_path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AsrError::InitializationFailed("missing 'model_path' in whisper config".to_string())
+            })?;
+        self.model_path = Some(model_path.to_string());
+
+        self.language = config
+            .get("language")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        tracing::info!(
+            model_path = %model_path,
+            language = ?self.language,
+            "WhisperEngine initialized (stub — model not loaded)"
+        );
+        Ok(())
+    }
+
+    async fn feed_audio(&self, _chunk: AudioChunk) -> Result<(), AsrError> {
+        // Stub: real inference deferred to when whisper-rs is actually wired
+        Ok(())
+    }
+
+    fn set_result_sender(&mut self, sender: mpsc::UnboundedSender<RecognitionResult>) {
+        *self.result_sender.lock().unwrap() = Some(sender);
+    }
+
+    async fn shutdown(&self) -> Result<(), AsrError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_whisper_engine_name() {
+        let engine = WhisperEngine::new();
+        assert_eq!(engine.name(), "whisper");
+    }
+
+    #[tokio::test]
+    async fn test_whisper_engine_initialize_missing_model_path_fails() {
+        let mut engine = WhisperEngine::new();
+        let result = engine
+            .initialize(toml::Value::Table(Default::default()))
+            .await;
+        match result {
+            Err(AsrError::InitializationFailed(msg)) => {
+                assert!(msg.contains("model_path"));
+            }
+            _ => panic!("expected InitializationFailed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_whisper_engine_initialize_with_config_succeeds() {
+        let mut engine = WhisperEngine::new();
+        let mut table = toml::map::Map::new();
+        table.insert(
+            "model_path".to_string(),
+            toml::Value::String("./models/test.bin".to_string()),
+        );
+        table.insert(
+            "language".to_string(),
+            toml::Value::String("ja".to_string()),
+        );
+        let result = engine.initialize(toml::Value::Table(table)).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_whisper_engine_implements_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<WhisperEngine>();
+    }
+}

--- a/crates/asr-engine/tests/integration.rs
+++ b/crates/asr-engine/tests/integration.rs
@@ -1,0 +1,130 @@
+use asr_core::AudioChunk;
+use asr_engine::{AsrHost, PluginRegistry};
+
+#[tokio::test]
+async fn test_full_pipeline_null_engine() {
+    let registry = PluginRegistry::new();
+    let mut host = AsrHost::new();
+    let mut rx = host.take_result_receiver().unwrap();
+
+    let tx = host
+        .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+        .await
+        .unwrap();
+    host.start();
+
+    let chunk = AudioChunk {
+        samples: vec![0.0; 480],
+        sample_rate: 48000,
+        channels: 1,
+    };
+    tx.send(chunk).unwrap();
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out")
+        .expect("channel closed");
+    assert_eq!(result.input_id, "mic1");
+    assert!(result.text.contains("480"));
+    assert!(result.is_final);
+
+    drop(tx);
+    host.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_full_pipeline_two_inputs() {
+    let registry = PluginRegistry::new();
+    let mut host = AsrHost::new();
+    let mut rx = host.take_result_receiver().unwrap();
+
+    let tx1 = host
+        .add_input("radio1", "null", toml::Value::Table(Default::default()), &registry)
+        .await
+        .unwrap();
+    let tx2 = host
+        .add_input("radio2", "null", toml::Value::Table(Default::default()), &registry)
+        .await
+        .unwrap();
+    host.start();
+
+    tx1.send(AudioChunk {
+        samples: vec![0.0; 100],
+        sample_rate: 48000,
+        channels: 1,
+    })
+    .unwrap();
+    tx2.send(AudioChunk {
+        samples: vec![0.0; 200],
+        sample_rate: 48000,
+        channels: 1,
+    })
+    .unwrap();
+
+    let timeout = std::time::Duration::from_secs(2);
+    let r1 = tokio::time::timeout(timeout, rx.recv())
+        .await
+        .expect("timed out")
+        .expect("closed");
+    let r2 = tokio::time::timeout(timeout, rx.recv())
+        .await
+        .expect("timed out")
+        .expect("closed");
+
+    let mut ids = vec![r1.input_id.clone(), r2.input_id.clone()];
+    ids.sort();
+    assert_eq!(ids, vec!["radio1", "radio2"]);
+
+    drop(tx1);
+    drop(tx2);
+    host.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_full_pipeline_shutdown_after_drop() {
+    let registry = PluginRegistry::new();
+    let mut host = AsrHost::new();
+
+    let tx = host
+        .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+        .await
+        .unwrap();
+    host.start();
+
+    drop(tx);
+
+    // Shutdown should complete without hanging
+    tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+        .await
+        .expect("shutdown timed out");
+}
+
+#[tokio::test]
+async fn test_full_pipeline_large_chunk() {
+    let registry = PluginRegistry::new();
+    let mut host = AsrHost::new();
+    let mut rx = host.take_result_receiver().unwrap();
+
+    let tx = host
+        .add_input("mic1", "null", toml::Value::Table(Default::default()), &registry)
+        .await
+        .unwrap();
+    host.start();
+
+    // 10 seconds of audio at 48kHz
+    let chunk = AudioChunk {
+        samples: vec![0.0; 480_000],
+        sample_rate: 48000,
+        channels: 1,
+    };
+    tx.send(chunk).unwrap();
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out")
+        .expect("channel closed");
+    assert!(result.text.contains("480000"));
+
+    drop(tx);
+    host.shutdown().await;
+}


### PR DESCRIPTION
## Summary
- Implement `AsrEngine` async trait in `asr-engine` crate for pluggable speech recognition backends
- Add `NullEngine` (test engine echoing sample counts), `WhisperEngine` stub (feature-gated), `PluginRegistry` (factory-based creation), and `AsrHost` orchestrator (tokio tasks bridging audio→engine→results)
- Add ASR tap to `CaptureNode` for feeding audio chunks to engines, and wire everything in `main.rs`

## Test plan
- [x] `cargo build --workspace` — compiles with no warnings
- [x] `cargo test --workspace` — 77 pass, 1 ignored (hardware-dependent)
- [x] `cargo test -p asr-engine --features whisper` — +4 whisper stub tests pass
- [ ] Manual: `cargo run` with `[asr] engine = "null"` → recognition results logged to stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)