### PR TITLE
Add Phase 4: Destination routing plugin system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "tracing-subscriber",
  "voxmux-audio",
  "voxmux-core",
+ "voxmux-destination",
  "voxmux-engine",
 ]
 
@@ -1190,6 +1191,14 @@ dependencies = [
 [[package]]
 name = "voxmux-destination"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "voxmux-core",
+]
 
 [[package]]
 name = "voxmux-engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ edition = "2021"
 voxmux-core = { workspace = true }
 voxmux-audio = { workspace = true }
 voxmux-engine = { workspace = true }
+voxmux-destination = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/voxmux-destination/Cargo.toml
+++ b/crates/voxmux-destination/Cargo.toml
@@ -4,3 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+voxmux-core = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+toml = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+default = []
+discord = []

--- a/crates/voxmux-destination/src/dest_trait.rs
+++ b/crates/voxmux-destination/src/dest_trait.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+use voxmux_core::{DestinationError, TextMetadata};
+
+#[async_trait]
+pub trait Destination: Send + Sync {
+    fn name(&self) -> &str;
+    async fn initialize(&mut self, config: toml::Value) -> Result<(), DestinationError>;
+    async fn send_text(&self, text: &str, metadata: &TextMetadata) -> Result<(), DestinationError>;
+    fn is_healthy(&self) -> bool;
+    async fn shutdown(&self) -> Result<(), DestinationError>;
+}

--- a/crates/voxmux-destination/src/discord_dest.rs
+++ b/crates/voxmux-destination/src/discord_dest.rs
@@ -1,0 +1,141 @@
+use crate::dest_trait::Destination;
+use async_trait::async_trait;
+use voxmux_core::{DestinationError, TextMetadata};
+
+pub struct DiscordDestination {
+    token: Option<String>,
+    guild_id: Option<u64>,
+    channel_id: Option<u64>,
+}
+
+impl DiscordDestination {
+    pub fn new() -> Self {
+        Self {
+            token: None,
+            guild_id: None,
+            channel_id: None,
+        }
+    }
+}
+
+impl Default for DiscordDestination {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Destination for DiscordDestination {
+    fn name(&self) -> &str {
+        "discord"
+    }
+
+    async fn initialize(&mut self, config: toml::Value) -> Result<(), DestinationError> {
+        let token = config
+            .get("token")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                DestinationError::InitializationFailed("missing 'token' in config".to_string())
+            })?;
+        let guild_id = config
+            .get("guild_id")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as u64);
+        let channel_id = config
+            .get("channel_id")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as u64);
+
+        self.token = Some(token.to_string());
+        self.guild_id = guild_id;
+        self.channel_id = channel_id;
+
+        tracing::info!("DiscordDestination initialized (stub)");
+        Ok(())
+    }
+
+    async fn send_text(
+        &self,
+        text: &str,
+        metadata: &TextMetadata,
+    ) -> Result<(), DestinationError> {
+        tracing::debug!(
+            input_id = %metadata.input_id,
+            "DiscordDestination stub send: {}{}",
+            metadata.prefix,
+            text,
+        );
+        Ok(())
+    }
+
+    fn is_healthy(&self) -> bool {
+        self.token.is_some()
+    }
+
+    async fn shutdown(&self) -> Result<(), DestinationError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discord_dest_name() {
+        let dest = DiscordDestination::new();
+        assert_eq!(dest.name(), "discord");
+    }
+
+    #[tokio::test]
+    async fn test_discord_dest_initialize_missing_token_fails() {
+        let mut dest = DiscordDestination::new();
+        let config = toml::Value::Table(Default::default());
+        let result = dest.initialize(config).await;
+        match result {
+            Err(DestinationError::InitializationFailed(msg)) => {
+                assert!(msg.contains("token"));
+            }
+            _ => panic!("expected InitializationFailed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_discord_dest_initialize_with_config_succeeds() {
+        let mut dest = DiscordDestination::new();
+        let config = toml::Value::Table({
+            let mut t = toml::map::Map::new();
+            t.insert("token".to_string(), toml::Value::String("bot-token".to_string()));
+            t.insert("guild_id".to_string(), toml::Value::Integer(12345));
+            t.insert("channel_id".to_string(), toml::Value::Integer(67890));
+            t
+        });
+        let result = dest.initialize(config).await;
+        assert!(result.is_ok());
+        assert!(dest.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn test_discord_dest_send_text_stub_succeeds() {
+        let mut dest = DiscordDestination::new();
+        let config = toml::Value::Table({
+            let mut t = toml::map::Map::new();
+            t.insert("token".to_string(), toml::Value::String("bot-token".to_string()));
+            t
+        });
+        dest.initialize(config).await.unwrap();
+
+        let metadata = TextMetadata {
+            input_id: "mic1".to_string(),
+            prefix: "[M1] ".to_string(),
+        };
+        let result = dest.send_text("hello", &metadata).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_discord_dest_implements_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<DiscordDestination>();
+    }
+}

--- a/crates/voxmux-destination/src/file_dest.rs
+++ b/crates/voxmux-destination/src/file_dest.rs
@@ -1,0 +1,238 @@
+use crate::dest_trait::Destination;
+use async_trait::async_trait;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use voxmux_core::{DestinationError, TextMetadata};
+
+pub struct FileDestination {
+    output_path: Mutex<Option<PathBuf>>,
+    send_count: AtomicUsize,
+}
+
+impl FileDestination {
+    pub fn new() -> Self {
+        Self {
+            output_path: Mutex::new(None),
+            send_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn send_count(&self) -> usize {
+        self.send_count.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for FileDestination {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Destination for FileDestination {
+    fn name(&self) -> &str {
+        "file"
+    }
+
+    async fn initialize(&mut self, config: toml::Value) -> Result<(), DestinationError> {
+        let path = config
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                DestinationError::InitializationFailed("missing 'path' in config".to_string())
+            })?;
+        *self.output_path.lock().unwrap() = Some(PathBuf::from(path));
+        Ok(())
+    }
+
+    async fn send_text(&self, text: &str, metadata: &TextMetadata) -> Result<(), DestinationError> {
+        let guard = self.output_path.lock().unwrap();
+        let path = guard.as_ref().ok_or_else(|| {
+            DestinationError::SendFailed("not initialized".to_string())
+        })?;
+
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| DestinationError::SendFailed(e.to_string()))?;
+
+        writeln!(file, "{}{}", metadata.prefix, text)
+            .map_err(|e| DestinationError::SendFailed(e.to_string()))?;
+
+        self.send_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn is_healthy(&self) -> bool {
+        self.output_path.lock().unwrap().is_some()
+    }
+
+    async fn shutdown(&self) -> Result<(), DestinationError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_dest_name() {
+        let dest = FileDestination::new();
+        assert_eq!(dest.name(), "file");
+    }
+
+    #[tokio::test]
+    async fn test_file_dest_initialize_sets_path() {
+        let mut dest = FileDestination::new();
+        let config = toml::Value::Table({
+            let mut t = toml::map::Map::new();
+            t.insert("path".to_string(), toml::Value::String("/tmp/test.txt".to_string()));
+            t
+        });
+        let result = dest.initialize(config).await;
+        assert!(result.is_ok());
+        assert!(dest.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn test_file_dest_initialize_missing_path_fails() {
+        let mut dest = FileDestination::new();
+        let config = toml::Value::Table(Default::default());
+        let result = dest.initialize(config).await;
+        match result {
+            Err(DestinationError::InitializationFailed(msg)) => {
+                assert!(msg.contains("path"));
+            }
+            _ => panic!("expected InitializationFailed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_dest_send_text_writes_to_file() {
+        let dir = std::env::temp_dir().join("voxmux_file_dest_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("output.txt");
+        // Clean up from previous runs
+        let _ = std::fs::remove_file(&path);
+
+        let mut dest = FileDestination::new();
+        let config = toml::Value::Table({
+            let mut t = toml::map::Map::new();
+            t.insert(
+                "path".to_string(),
+                toml::Value::String(path.to_string_lossy().to_string()),
+            );
+            t
+        });
+        dest.initialize(config).await.unwrap();
+
+        let metadata = TextMetadata {
+            input_id: "mic1".to_string(),
+            prefix: "[M1] ".to_string(),
+        };
+        dest.send_text("hello world", &metadata).await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "[M1] hello world\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_file_dest_send_text_appends() {
+        let dir = std::env::temp_dir().join("voxmux_file_dest_append");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("output.txt");
+        let _ = std::fs::remove_file(&path);
+
+        let mut dest = FileDestination::new();
+        let config = toml::Value::Table({
+            let mut t = toml::map::Map::new();
+            t.insert(
+                "path".to_string(),
+                toml::Value::String(path.to_string_lossy().to_string()),
+            );
+            t
+        });
+        dest.initialize(config).await.unwrap();
+
+        let metadata = TextMetadata {
+            input_id: "mic1".to_string(),
+            prefix: "".to_string(),
+        };
+        dest.send_text("line one", &metadata).await.unwrap();
+        dest.send_text("line two", &metadata).await.unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "line one\nline two\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_file_dest_send_text_before_initialize_fails() {
+        let dest = FileDestination::new();
+        let metadata = TextMetadata {
+            input_id: "mic1".to_string(),
+            prefix: "".to_string(),
+        };
+        let result = dest.send_text("test", &metadata).await;
+        match result {
+            Err(DestinationError::SendFailed(_)) => {}
+            _ => panic!("expected SendFailed"),
+        }
+    }
+
+    #[test]
+    fn test_file_dest_is_healthy_before_init() {
+        let dest = FileDestination::new();
+        assert!(!dest.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn test_file_dest_shutdown_succeeds() {
+        let dest = FileDestination::new();
+        let result = dest.shutdown().await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_file_dest_implements_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FileDestination>();
+    }
+
+    #[tokio::test]
+    async fn test_file_dest_send_count() {
+        let dir = std::env::temp_dir().join("voxmux_file_dest_count");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("output.txt");
+        let _ = std::fs::remove_file(&path);
+
+        let mut dest = FileDestination::new();
+        let config = toml::Value::Table({
+            let mut t = toml::map::Map::new();
+            t.insert(
+                "path".to_string(),
+                toml::Value::String(path.to_string_lossy().to_string()),
+            );
+            t
+        });
+        dest.initialize(config).await.unwrap();
+
+        let metadata = TextMetadata {
+            input_id: "mic1".to_string(),
+            prefix: "".to_string(),
+        };
+        for _ in 0..3 {
+            dest.send_text("msg", &metadata).await.unwrap();
+        }
+        assert_eq!(dest.send_count(), 3);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/voxmux-destination/src/host.rs
+++ b/crates/voxmux-destination/src/host.rs
@@ -1,0 +1,354 @@
+use crate::dest_trait::Destination;
+use crate::registry::DestinationRegistry;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+use voxmux_core::{DestinationError, RecognitionResult, TextMetadata};
+
+struct Route {
+    destination: Box<dyn Destination>,
+    prefix: String,
+}
+
+pub struct DestinationHost {
+    registry: DestinationRegistry,
+    routes: HashMap<String, Vec<Route>>,
+    result_rx: Option<mpsc::UnboundedReceiver<RecognitionResult>>,
+    task_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl DestinationHost {
+    pub fn new(result_rx: mpsc::UnboundedReceiver<RecognitionResult>) -> Self {
+        Self {
+            registry: DestinationRegistry::new(),
+            routes: HashMap::new(),
+            result_rx: Some(result_rx),
+            task_handle: None,
+        }
+    }
+
+    pub async fn add_route(
+        &mut self,
+        input_id: &str,
+        plugin_name: &str,
+        prefix: &str,
+        config: toml::Value,
+    ) -> Result<(), DestinationError> {
+        let mut dest = self.registry.create(plugin_name)?;
+        dest.initialize(config).await?;
+
+        let route = Route {
+            destination: dest,
+            prefix: prefix.to_string(),
+        };
+
+        self.routes
+            .entry(input_id.to_string())
+            .or_default()
+            .push(route);
+
+        Ok(())
+    }
+
+    pub fn start(&mut self) {
+        let mut rx = self
+            .result_rx
+            .take()
+            .expect("start() called but receiver already taken");
+        let routes = std::mem::take(&mut self.routes);
+
+        let handle = tokio::spawn(async move {
+            while let Some(result) = rx.recv().await {
+                if !result.is_final {
+                    continue;
+                }
+
+                if let Some(input_routes) = routes.get(&result.input_id) {
+                    for route in input_routes {
+                        let metadata = TextMetadata {
+                            input_id: result.input_id.clone(),
+                            prefix: route.prefix.clone(),
+                        };
+                        if let Err(e) = route.destination.send_text(&result.text, &metadata).await
+                        {
+                            tracing::error!(
+                                input_id = %result.input_id,
+                                destination = %route.destination.name(),
+                                "send_text failed: {e}"
+                            );
+                        }
+                    }
+                }
+            }
+        });
+
+        self.task_handle = Some(handle);
+    }
+
+    pub async fn shutdown(&mut self) {
+        if let Some(handle) = self.task_handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_channel() -> (
+        mpsc::UnboundedSender<RecognitionResult>,
+        mpsc::UnboundedReceiver<RecognitionResult>,
+    ) {
+        mpsc::unbounded_channel()
+    }
+
+    fn make_result(input_id: &str, text: &str, is_final: bool) -> RecognitionResult {
+        RecognitionResult {
+            text: text.to_string(),
+            input_id: input_id.to_string(),
+            timestamp: 0.0,
+            is_final,
+        }
+    }
+
+    fn file_config(path: &str) -> toml::Value {
+        toml::Value::Table({
+            let mut t = toml::map::Map::new();
+            t.insert("path".to_string(), toml::Value::String(path.to_string()));
+            t
+        })
+    }
+
+    #[test]
+    fn test_host_new_creates_successfully() {
+        let (_tx, rx) = make_channel();
+        let _host = DestinationHost::new(rx);
+    }
+
+    #[tokio::test]
+    async fn test_host_add_route_returns_ok() {
+        let (_tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let dir = std::env::temp_dir().join("voxmux_host_add_route");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.txt");
+
+        let result = host
+            .add_route("mic1", "file", "[M1] ", file_config(&path.to_string_lossy()))
+            .await;
+        assert!(result.is_ok());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_host_add_route_unknown_plugin_fails() {
+        let (_tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let result = host
+            .add_route("mic1", "nonexistent", "", toml::Value::Table(Default::default()))
+            .await;
+        match result {
+            Err(DestinationError::NotFound(_)) => {}
+            _ => panic!("expected NotFound"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_host_start_and_send_result_routes_to_file() {
+        let (tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let dir = std::env::temp_dir().join("voxmux_host_route_file");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.txt");
+        let _ = std::fs::remove_file(&path);
+
+        host.add_route("mic1", "file", "[M1] ", file_config(&path.to_string_lossy()))
+            .await
+            .unwrap();
+        host.start();
+
+        tx.send(make_result("mic1", "hello", true)).unwrap();
+        drop(tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "[M1] hello\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_host_routes_to_correct_input() {
+        let (tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let dir = std::env::temp_dir().join("voxmux_host_correct_input");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path1 = dir.join("mic1.txt");
+        let path2 = dir.join("mic2.txt");
+        let _ = std::fs::remove_file(&path1);
+        let _ = std::fs::remove_file(&path2);
+
+        host.add_route("mic1", "file", "", file_config(&path1.to_string_lossy()))
+            .await
+            .unwrap();
+        host.add_route("mic2", "file", "", file_config(&path2.to_string_lossy()))
+            .await
+            .unwrap();
+        host.start();
+
+        tx.send(make_result("mic1", "from mic1", true)).unwrap();
+        drop(tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+
+        let contents1 = std::fs::read_to_string(&path1).unwrap();
+        assert_eq!(contents1, "from mic1\n");
+        // mic2 file should not exist since nothing was routed to it
+        assert!(!path2.exists());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_host_multiple_destinations_per_input() {
+        let (tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let dir = std::env::temp_dir().join("voxmux_host_fanout");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path_a = dir.join("a.txt");
+        let path_b = dir.join("b.txt");
+        let _ = std::fs::remove_file(&path_a);
+        let _ = std::fs::remove_file(&path_b);
+
+        host.add_route("mic1", "file", "[A] ", file_config(&path_a.to_string_lossy()))
+            .await
+            .unwrap();
+        host.add_route("mic1", "file", "[B] ", file_config(&path_b.to_string_lossy()))
+            .await
+            .unwrap();
+        host.start();
+
+        tx.send(make_result("mic1", "fanout", true)).unwrap();
+        drop(tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+
+        let a = std::fs::read_to_string(&path_a).unwrap();
+        let b = std::fs::read_to_string(&path_b).unwrap();
+        assert_eq!(a, "[A] fanout\n");
+        assert_eq!(b, "[B] fanout\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_host_ignores_unrouted_input() {
+        let (tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let dir = std::env::temp_dir().join("voxmux_host_unrouted");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.txt");
+        let _ = std::fs::remove_file(&path);
+
+        host.add_route("mic1", "file", "", file_config(&path.to_string_lossy()))
+            .await
+            .unwrap();
+        host.start();
+
+        // Send result for an unrouted input — should not crash
+        tx.send(make_result("mic_unknown", "ignored", true)).unwrap();
+        drop(tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+
+        // File should be empty (or not exist) since nothing matched mic1
+        let exists = path.exists();
+        if exists {
+            let contents = std::fs::read_to_string(&path).unwrap();
+            assert!(contents.is_empty());
+        }
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_host_shutdown_completes() {
+        let (_tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        host.start();
+
+        // Drop the sender so the task finishes
+        drop(_tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+    }
+
+    #[tokio::test]
+    async fn test_host_processes_multiple_results() {
+        let (tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let dir = std::env::temp_dir().join("voxmux_host_multi_results");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.txt");
+        let _ = std::fs::remove_file(&path);
+
+        host.add_route("mic1", "file", "", file_config(&path.to_string_lossy()))
+            .await
+            .unwrap();
+        host.start();
+
+        tx.send(make_result("mic1", "one", true)).unwrap();
+        tx.send(make_result("mic1", "two", true)).unwrap();
+        tx.send(make_result("mic1", "three", true)).unwrap();
+        drop(tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "one\ntwo\nthree\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_host_only_routes_final_results() {
+        let (tx, rx) = make_channel();
+        let mut host = DestinationHost::new(rx);
+        let dir = std::env::temp_dir().join("voxmux_host_final_only");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.txt");
+        let _ = std::fs::remove_file(&path);
+
+        host.add_route("mic1", "file", "", file_config(&path.to_string_lossy()))
+            .await
+            .unwrap();
+        host.start();
+
+        tx.send(make_result("mic1", "partial", false)).unwrap();
+        tx.send(make_result("mic1", "final", true)).unwrap();
+        drop(tx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+            .await
+            .expect("shutdown timed out");
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "final\n");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/voxmux-destination/src/lib.rs
+++ b/crates/voxmux-destination/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod dest_trait;
+#[cfg(feature = "discord")]
+pub mod discord_dest;
+pub mod file_dest;
+pub mod host;
+pub mod registry;
+
+pub use dest_trait::Destination;
+#[cfg(feature = "discord")]
+pub use discord_dest::DiscordDestination;
+pub use file_dest::FileDestination;
+pub use host::DestinationHost;
+pub use registry::DestinationRegistry;

--- a/crates/voxmux-destination/src/registry.rs
+++ b/crates/voxmux-destination/src/registry.rs
@@ -1,0 +1,95 @@
+use crate::dest_trait::Destination;
+use std::collections::HashMap;
+use voxmux_core::DestinationError;
+
+pub struct DestinationRegistry {
+    factories: HashMap<String, fn() -> Box<dyn Destination>>,
+}
+
+impl DestinationRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            factories: HashMap::new(),
+        };
+        registry.register("file", || Box::new(crate::file_dest::FileDestination::new()));
+        #[cfg(feature = "discord")]
+        registry.register("discord", || {
+            Box::new(crate::discord_dest::DiscordDestination::new())
+        });
+        registry
+    }
+
+    pub fn register(&mut self, name: &str, factory: fn() -> Box<dyn Destination>) {
+        self.factories.insert(name.to_string(), factory);
+    }
+
+    pub fn create(&self, name: &str) -> Result<Box<dyn Destination>, DestinationError> {
+        self.factories
+            .get(name)
+            .map(|f| f())
+            .ok_or_else(|| DestinationError::NotFound(name.to_string()))
+    }
+
+    pub fn list_destinations(&self) -> Vec<&str> {
+        self.factories.keys().map(|s| s.as_str()).collect()
+    }
+}
+
+impl Default for DestinationRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FileDestination;
+
+    #[test]
+    fn test_registry_new_has_file_destination() {
+        let registry = DestinationRegistry::new();
+        assert!(registry.create("file").is_ok());
+    }
+
+    #[test]
+    fn test_registry_create_file_returns_correct_name() {
+        let registry = DestinationRegistry::new();
+        let dest = registry.create("file").unwrap();
+        assert_eq!(dest.name(), "file");
+    }
+
+    #[test]
+    fn test_registry_create_unknown_returns_error() {
+        let registry = DestinationRegistry::new();
+        let result = registry.create("nope");
+        match result {
+            Err(DestinationError::NotFound(name)) => assert_eq!(name, "nope"),
+            _ => panic!("expected NotFound error"),
+        }
+    }
+
+    #[test]
+    fn test_registry_register_custom_destination() {
+        let mut registry = DestinationRegistry::new();
+        registry.register("custom", || Box::new(FileDestination::new()));
+        let dest = registry.create("custom").unwrap();
+        // FileDestination is used as the factory, so name is "file"
+        assert_eq!(dest.name(), "file");
+    }
+
+    #[test]
+    fn test_registry_list_destinations_includes_file() {
+        let registry = DestinationRegistry::new();
+        let dests = registry.list_destinations();
+        assert!(dests.contains(&"file"));
+    }
+
+    #[test]
+    fn test_registry_register_overwrites() {
+        let mut registry = DestinationRegistry::new();
+        registry.register("file", || Box::new(FileDestination::new()));
+        let dest = registry.create("file").unwrap();
+        assert_eq!(dest.name(), "file");
+    }
+}

--- a/crates/voxmux-destination/tests/integration.rs
+++ b/crates/voxmux-destination/tests/integration.rs
@@ -1,0 +1,143 @@
+use tokio::sync::mpsc;
+use voxmux_core::RecognitionResult;
+use voxmux_destination::DestinationHost;
+
+fn make_result(input_id: &str, text: &str, is_final: bool) -> RecognitionResult {
+    RecognitionResult {
+        text: text.to_string(),
+        input_id: input_id.to_string(),
+        timestamp: 0.0,
+        is_final,
+    }
+}
+
+fn file_config(path: &str) -> toml::Value {
+    toml::Value::Table({
+        let mut t = toml::map::Map::new();
+        t.insert("path".to_string(), toml::Value::String(path.to_string()));
+        t
+    })
+}
+
+#[tokio::test]
+async fn test_full_pipeline_single_route() {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut host = DestinationHost::new(rx);
+
+    let dir = std::env::temp_dir().join("voxmux_integ_single");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("out.txt");
+    let _ = std::fs::remove_file(&path);
+
+    host.add_route("mic1", "file", "[M1] ", file_config(&path.to_string_lossy()))
+        .await
+        .unwrap();
+    host.start();
+
+    tx.send(make_result("mic1", "hello world", true)).unwrap();
+    drop(tx);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+        .await
+        .expect("shutdown timed out");
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(contents, "[M1] hello world\n");
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn test_full_pipeline_multiple_inputs() {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut host = DestinationHost::new(rx);
+
+    let dir = std::env::temp_dir().join("voxmux_integ_multi_input");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path1 = dir.join("mic1.txt");
+    let path2 = dir.join("mic2.txt");
+    let _ = std::fs::remove_file(&path1);
+    let _ = std::fs::remove_file(&path2);
+
+    host.add_route("mic1", "file", "[M1] ", file_config(&path1.to_string_lossy()))
+        .await
+        .unwrap();
+    host.add_route("mic2", "file", "[M2] ", file_config(&path2.to_string_lossy()))
+        .await
+        .unwrap();
+    host.start();
+
+    tx.send(make_result("mic1", "from one", true)).unwrap();
+    tx.send(make_result("mic2", "from two", true)).unwrap();
+    drop(tx);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+        .await
+        .expect("shutdown timed out");
+
+    let c1 = std::fs::read_to_string(&path1).unwrap();
+    let c2 = std::fs::read_to_string(&path2).unwrap();
+    assert_eq!(c1, "[M1] from one\n");
+    assert_eq!(c2, "[M2] from two\n");
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn test_full_pipeline_fan_out() {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut host = DestinationHost::new(rx);
+
+    let dir = std::env::temp_dir().join("voxmux_integ_fanout");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path_a = dir.join("a.txt");
+    let path_b = dir.join("b.txt");
+    let _ = std::fs::remove_file(&path_a);
+    let _ = std::fs::remove_file(&path_b);
+
+    host.add_route("mic1", "file", "[A] ", file_config(&path_a.to_string_lossy()))
+        .await
+        .unwrap();
+    host.add_route("mic1", "file", "[B] ", file_config(&path_b.to_string_lossy()))
+        .await
+        .unwrap();
+    host.start();
+
+    tx.send(make_result("mic1", "fanout", true)).unwrap();
+    drop(tx);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+        .await
+        .expect("shutdown timed out");
+
+    let a = std::fs::read_to_string(&path_a).unwrap();
+    let b = std::fs::read_to_string(&path_b).unwrap();
+    assert_eq!(a, "[A] fanout\n");
+    assert_eq!(b, "[B] fanout\n");
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn test_full_pipeline_shutdown_after_sender_drop() {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut host = DestinationHost::new(rx);
+
+    let dir = std::env::temp_dir().join("voxmux_integ_drop");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("out.txt");
+
+    host.add_route("mic1", "file", "", file_config(&path.to_string_lossy()))
+        .await
+        .unwrap();
+    host.start();
+
+    // Drop sender immediately — should not hang
+    drop(tx);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), host.shutdown())
+        .await
+        .expect("shutdown should not hang after sender drop");
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}


### PR DESCRIPTION
## Summary
- Implements destination plugin architecture mirroring `voxmux-engine` (trait → impl → registry → host)
- `FileDestination` writes prefixed ASR text to files; `DiscordDestination` is a feature-gated stub
- `DestinationHost` routes `RecognitionResult`s by `input_id` with fan-out support, skipping non-final results
- `main.rs` wired to create routes from config, merging global `[destinations.plugin]` with per-route extras; falls back to logging when no destinations configured

## Test plan
- [x] `cargo build --workspace` — no errors
- [x] `cargo test --workspace` — 107 pass, 1 ignored (hardware)
- [x] `cargo test -p voxmux-destination --features discord` — 35 pass (31 unit + 4 integration)
- [x] `cargo test -p voxmux-engine --features whisper` — 30 pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)