### PR TITLE
Add Phase 5: TUI dashboard with ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +270,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +339,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +430,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -381,6 +481,17 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -392,13 +503,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -415,6 +554,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni"
@@ -481,6 +626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +645,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "mach2"
@@ -532,6 +692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -685,6 +846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +912,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,10 +988,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -875,6 +1082,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,10 +1135,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1139,6 +1395,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1449,7 @@ dependencies = [
  "voxmux-core",
  "voxmux-destination",
  "voxmux-engine",
+ "voxmux-tui",
 ]
 
 [[package]]
@@ -1219,6 +1505,14 @@ version = "0.1.0"
 [[package]]
 name = "voxmux-tui"
 version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "voxmux-core",
+]
 
 [[package]]
 name = "walkdir"
@@ -1315,6 +1609,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1632,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -1365,6 +1681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4.5", features = ["derive"] }
 regex = "1"
 async-trait = "0.1"
+ratatui = "0.29"
+crossterm = "0.28"
 
 # Internal crates
 voxmux-core = { path = "crates/voxmux-core" }
@@ -41,6 +43,7 @@ voxmux-core = { workspace = true }
 voxmux-audio = { workspace = true }
 voxmux-engine = { workspace = true }
 voxmux-destination = { workspace = true }
+voxmux-tui = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/voxmux-core/src/lib.rs
+++ b/crates/voxmux-core/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod error;
+pub mod tui_types;
 pub mod types;
 
 pub use config::AppConfig;
 pub use error::{AsrError, AudioError, ConfigError, DestinationError};
+pub use tui_types::{InputState, OutputState, RouterState, UiCommand};
 pub use types::{AudioChunk, RecognitionResult, TextMetadata};
 
 #[cfg(test)]

--- a/crates/voxmux-core/src/tui_types.rs
+++ b/crates/voxmux-core/src/tui_types.rs
@@ -1,0 +1,102 @@
+/// State of a single audio input, for TUI display.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct InputState {
+    pub id: String,
+    pub device_name: String,
+    pub enabled: bool,
+    pub volume: f32,
+    pub muted: bool,
+    pub peak_level: f32,
+}
+
+/// State of the audio output, for TUI display.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutputState {
+    pub device_name: String,
+    pub play_mixed_input: bool,
+}
+
+impl Default for OutputState {
+    fn default() -> Self {
+        Self {
+            device_name: "default".to_string(),
+            play_mixed_input: true,
+        }
+    }
+}
+
+/// Aggregate router state broadcast to the TUI via watch channel.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RouterState {
+    pub inputs: Vec<InputState>,
+    pub output: OutputState,
+    pub latest_recognitions: Vec<String>,
+    pub is_running: bool,
+}
+
+/// Commands sent from TUI → main via mpsc channel.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UiCommand {
+    SetVolume { input_id: String, volume: f32 },
+    SetMuted { input_id: String, muted: bool },
+    SetEnabled { input_id: String, enabled: bool },
+    SetPlayMixedInput(bool),
+    Quit,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_router_state_default() {
+        let state = RouterState::default();
+        assert!(state.inputs.is_empty());
+        assert!(!state.is_running);
+        assert!(state.latest_recognitions.is_empty());
+        assert_eq!(state.output, OutputState::default());
+    }
+
+    #[test]
+    fn test_input_state_default() {
+        let input = InputState::default();
+        assert_eq!(input.volume, 0.0);
+        assert!(!input.enabled);
+        assert!(!input.muted);
+        assert_eq!(input.peak_level, 0.0);
+        assert!(input.id.is_empty());
+        assert!(input.device_name.is_empty());
+    }
+
+    #[test]
+    fn test_ui_command_clone_eq() {
+        let cmd = UiCommand::SetVolume {
+            input_id: "mic1".to_string(),
+            volume: 0.75,
+        };
+        let cloned = cmd.clone();
+        assert_eq!(cmd, cloned);
+    }
+
+    #[test]
+    fn test_router_state_is_clone() {
+        let state = RouterState {
+            inputs: vec![InputState {
+                id: "mic1".to_string(),
+                device_name: "USB Mic".to_string(),
+                enabled: true,
+                volume: 0.8,
+                muted: false,
+                peak_level: 0.5,
+            }],
+            output: OutputState {
+                device_name: "speakers".to_string(),
+                play_mixed_input: true,
+            },
+            latest_recognitions: vec!["hello".to_string()],
+            is_running: true,
+        };
+        let cloned = state.clone();
+        assert_eq!(state, cloned);
+    }
+}

--- a/crates/voxmux-tui/Cargo.toml
+++ b/crates/voxmux-tui/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+voxmux-core = { workspace = true }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/voxmux-tui/src/app.rs
+++ b/crates/voxmux-tui/src/app.rs
@@ -1,0 +1,412 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crossterm::event::{KeyCode, KeyEvent};
+use voxmux_core::tui_types::{RouterState, UiCommand};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tab {
+    Dashboard,
+    Inputs,
+    Outputs,
+    Logs,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AppAction {
+    None,
+    Quit,
+    Command(UiCommand),
+}
+
+pub struct App {
+    pub tab: Tab,
+    pub state: RouterState,
+    pub selected_input: usize,
+    pub should_quit: bool,
+    pub logs: Arc<Mutex<VecDeque<String>>>,
+    pub log_scroll: usize,
+    pub log_auto_scroll: bool,
+}
+
+impl App {
+    pub fn new(logs: Arc<Mutex<VecDeque<String>>>) -> Self {
+        Self {
+            tab: Tab::Dashboard,
+            state: RouterState::default(),
+            selected_input: 0,
+            should_quit: false,
+            logs,
+            log_scroll: 0,
+            log_auto_scroll: true,
+        }
+    }
+
+    pub fn update_state(&mut self, new_state: RouterState) {
+        self.state = new_state;
+        // Clamp selected_input to valid range
+        if !self.state.inputs.is_empty() && self.selected_input >= self.state.inputs.len() {
+            self.selected_input = self.state.inputs.len() - 1;
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> AppAction {
+        // Global keys
+        match key.code {
+            KeyCode::Char('q') => {
+                self.should_quit = true;
+                return AppAction::Quit;
+            }
+            KeyCode::Char('1') => {
+                self.tab = Tab::Dashboard;
+                return AppAction::None;
+            }
+            KeyCode::Char('2') => {
+                self.tab = Tab::Inputs;
+                return AppAction::None;
+            }
+            KeyCode::Char('3') => {
+                self.tab = Tab::Outputs;
+                return AppAction::None;
+            }
+            KeyCode::Char('4') => {
+                self.tab = Tab::Logs;
+                return AppAction::None;
+            }
+            _ => {}
+        }
+
+        // Tab-specific keys
+        match self.tab {
+            Tab::Inputs => self.handle_inputs_key(key),
+            Tab::Outputs => self.handle_outputs_key(key),
+            Tab::Logs => self.handle_logs_key(key),
+            Tab::Dashboard => AppAction::None,
+        }
+    }
+
+    fn handle_inputs_key(&mut self, key: KeyEvent) -> AppAction {
+        if self.state.inputs.is_empty() {
+            return AppAction::None;
+        }
+
+        match key.code {
+            KeyCode::Up => {
+                if self.selected_input > 0 {
+                    self.selected_input -= 1;
+                }
+                AppAction::None
+            }
+            KeyCode::Down => {
+                if self.selected_input + 1 < self.state.inputs.len() {
+                    self.selected_input += 1;
+                }
+                AppAction::None
+            }
+            KeyCode::Right => {
+                let input = &self.state.inputs[self.selected_input];
+                let new_vol = (input.volume + 0.05).min(1.0);
+                AppAction::Command(UiCommand::SetVolume {
+                    input_id: input.id.clone(),
+                    volume: new_vol,
+                })
+            }
+            KeyCode::Left => {
+                let input = &self.state.inputs[self.selected_input];
+                let new_vol = (input.volume - 0.05).max(0.0);
+                AppAction::Command(UiCommand::SetVolume {
+                    input_id: input.id.clone(),
+                    volume: new_vol,
+                })
+            }
+            KeyCode::Char('m') => {
+                let input = &self.state.inputs[self.selected_input];
+                AppAction::Command(UiCommand::SetMuted {
+                    input_id: input.id.clone(),
+                    muted: !input.muted,
+                })
+            }
+            KeyCode::Char('e') => {
+                let input = &self.state.inputs[self.selected_input];
+                AppAction::Command(UiCommand::SetEnabled {
+                    input_id: input.id.clone(),
+                    enabled: !input.enabled,
+                })
+            }
+            _ => AppAction::None,
+        }
+    }
+
+    fn handle_outputs_key(&mut self, key: KeyEvent) -> AppAction {
+        match key.code {
+            KeyCode::Char(' ') => AppAction::Command(UiCommand::SetPlayMixedInput(
+                !self.state.output.play_mixed_input,
+            )),
+            _ => AppAction::None,
+        }
+    }
+
+    fn handle_logs_key(&mut self, key: KeyEvent) -> AppAction {
+        match key.code {
+            KeyCode::Up => {
+                self.log_scroll = self.log_scroll.saturating_add(1);
+                self.log_auto_scroll = false;
+                AppAction::None
+            }
+            KeyCode::Down => {
+                self.log_scroll = self.log_scroll.saturating_sub(1);
+                AppAction::None
+            }
+            KeyCode::Char('G') => {
+                self.log_scroll = 0;
+                self.log_auto_scroll = true;
+                AppAction::None
+            }
+            _ => AppAction::None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use voxmux_core::tui_types::InputState;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn make_app() -> App {
+        App::new(Arc::new(Mutex::new(VecDeque::new())))
+    }
+
+    fn make_app_with_inputs(inputs: Vec<InputState>) -> App {
+        let mut app = make_app();
+        app.update_state(RouterState {
+            inputs,
+            ..Default::default()
+        });
+        app
+    }
+
+    // ── Step 3: App struct + state ─────────────────────────────
+
+    #[test]
+    fn test_app_initial_state() {
+        let app = make_app();
+        assert_eq!(app.tab, Tab::Dashboard);
+        assert_eq!(app.selected_input, 0);
+        assert!(!app.should_quit);
+        assert_eq!(app.log_scroll, 0);
+        assert!(app.log_auto_scroll);
+    }
+
+    #[test]
+    fn test_app_tab_switching() {
+        let mut app = make_app();
+        app.handle_key(key(KeyCode::Char('2')));
+        assert_eq!(app.tab, Tab::Inputs);
+        app.handle_key(key(KeyCode::Char('3')));
+        assert_eq!(app.tab, Tab::Outputs);
+        app.handle_key(key(KeyCode::Char('4')));
+        assert_eq!(app.tab, Tab::Logs);
+        app.handle_key(key(KeyCode::Char('1')));
+        assert_eq!(app.tab, Tab::Dashboard);
+    }
+
+    #[test]
+    fn test_app_state_update() {
+        let mut app = make_app();
+        let state = RouterState {
+            inputs: vec![
+                InputState {
+                    id: "a".into(),
+                    ..Default::default()
+                },
+                InputState {
+                    id: "b".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        app.update_state(state);
+        assert_eq!(app.state.inputs.len(), 2);
+    }
+
+    #[test]
+    fn test_app_log_auto_scroll() {
+        let mut app = make_app();
+        app.tab = Tab::Logs;
+
+        // Scroll up → auto_scroll = false
+        app.handle_key(key(KeyCode::Up));
+        assert!(!app.log_auto_scroll);
+        assert_eq!(app.log_scroll, 1);
+
+        // Press G → auto_scroll = true, scroll = 0
+        app.handle_key(key(KeyCode::Char('G')));
+        assert!(app.log_auto_scroll);
+        assert_eq!(app.log_scroll, 0);
+    }
+
+    // ── Step 4: Key event handling ─────────────────────────────
+
+    #[test]
+    fn test_app_volume_up() {
+        let mut app = make_app_with_inputs(vec![InputState {
+            id: "mic1".into(),
+            volume: 0.5,
+            ..Default::default()
+        }]);
+        app.tab = Tab::Inputs;
+        let action = app.handle_key(key(KeyCode::Right));
+        assert_eq!(
+            action,
+            AppAction::Command(UiCommand::SetVolume {
+                input_id: "mic1".into(),
+                volume: 0.55,
+            })
+        );
+    }
+
+    #[test]
+    fn test_app_volume_down() {
+        let mut app = make_app_with_inputs(vec![InputState {
+            id: "mic1".into(),
+            volume: 0.5,
+            ..Default::default()
+        }]);
+        app.tab = Tab::Inputs;
+        let action = app.handle_key(key(KeyCode::Left));
+        match action {
+            AppAction::Command(UiCommand::SetVolume { input_id, volume }) => {
+                assert_eq!(input_id, "mic1");
+                assert!((volume - 0.45).abs() < 1e-5, "expected ~0.45, got {}", volume);
+            }
+            other => panic!("expected SetVolume command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_app_volume_clamp() {
+        // At max
+        let mut app = make_app_with_inputs(vec![InputState {
+            id: "mic1".into(),
+            volume: 1.0,
+            ..Default::default()
+        }]);
+        app.tab = Tab::Inputs;
+        let action = app.handle_key(key(KeyCode::Right));
+        assert_eq!(
+            action,
+            AppAction::Command(UiCommand::SetVolume {
+                input_id: "mic1".into(),
+                volume: 1.0,
+            })
+        );
+
+        // At min
+        let mut app = make_app_with_inputs(vec![InputState {
+            id: "mic1".into(),
+            volume: 0.0,
+            ..Default::default()
+        }]);
+        app.tab = Tab::Inputs;
+        let action = app.handle_key(key(KeyCode::Left));
+        assert_eq!(
+            action,
+            AppAction::Command(UiCommand::SetVolume {
+                input_id: "mic1".into(),
+                volume: 0.0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_app_mute_toggle() {
+        let mut app = make_app_with_inputs(vec![InputState {
+            id: "mic1".into(),
+            muted: false,
+            ..Default::default()
+        }]);
+        app.tab = Tab::Inputs;
+        let action = app.handle_key(key(KeyCode::Char('m')));
+        assert_eq!(
+            action,
+            AppAction::Command(UiCommand::SetMuted {
+                input_id: "mic1".into(),
+                muted: true,
+            })
+        );
+    }
+
+    #[test]
+    fn test_app_enable_toggle() {
+        let mut app = make_app_with_inputs(vec![InputState {
+            id: "mic1".into(),
+            enabled: true,
+            ..Default::default()
+        }]);
+        app.tab = Tab::Inputs;
+        let action = app.handle_key(key(KeyCode::Char('e')));
+        assert_eq!(
+            action,
+            AppAction::Command(UiCommand::SetEnabled {
+                input_id: "mic1".into(),
+                enabled: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_app_play_mixed_toggle() {
+        let mut app = make_app();
+        app.state.output.play_mixed_input = true;
+        app.tab = Tab::Outputs;
+        let action = app.handle_key(key(KeyCode::Char(' ')));
+        assert_eq!(
+            action,
+            AppAction::Command(UiCommand::SetPlayMixedInput(false))
+        );
+    }
+
+    #[test]
+    fn test_app_quit() {
+        let mut app = make_app();
+        let action = app.handle_key(key(KeyCode::Char('q')));
+        assert_eq!(action, AppAction::Quit);
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_app_log_scroll() {
+        let logs = Arc::new(Mutex::new(VecDeque::new()));
+        {
+            let mut buf = logs.lock().unwrap();
+            for i in 0..20 {
+                buf.push_back(format!("log line {}", i));
+            }
+        }
+        let mut app = App::new(logs);
+        app.tab = Tab::Logs;
+
+        // Up → scroll increases
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.log_scroll, 1);
+        assert!(!app.log_auto_scroll);
+
+        // Down → scroll decreases
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(app.log_scroll, 0);
+
+        // G → scroll to bottom, auto_scroll on
+        app.handle_key(key(KeyCode::Up));
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.log_scroll, 2);
+        app.handle_key(key(KeyCode::Char('G')));
+        assert_eq!(app.log_scroll, 0);
+        assert!(app.log_auto_scroll);
+    }
+}

--- a/crates/voxmux-tui/src/lib.rs
+++ b/crates/voxmux-tui/src/lib.rs
@@ -1,0 +1,65 @@
+pub mod app;
+pub mod log_layer;
+pub mod ui;
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crossterm::event::{self, Event, KeyEventKind};
+use ratatui::DefaultTerminal;
+use tokio::sync::{mpsc, watch};
+use voxmux_core::tui_types::{RouterState, UiCommand};
+
+pub use app::App;
+pub use log_layer::TuiLogLayer;
+
+/// Run the TUI event loop. Blocks until the user quits.
+pub async fn run(
+    mut state_rx: watch::Receiver<RouterState>,
+    cmd_tx: mpsc::UnboundedSender<UiCommand>,
+    log_buffer: Arc<Mutex<VecDeque<String>>>,
+) -> std::io::Result<()> {
+    let mut terminal = ratatui::init();
+    let result = run_loop(&mut terminal, &mut state_rx, &cmd_tx, &log_buffer).await;
+    ratatui::restore();
+    result
+}
+
+async fn run_loop(
+    terminal: &mut DefaultTerminal,
+    state_rx: &mut watch::Receiver<RouterState>,
+    cmd_tx: &mpsc::UnboundedSender<UiCommand>,
+    log_buffer: &Arc<Mutex<VecDeque<String>>>,
+) -> std::io::Result<()> {
+    let mut app = App::new(Arc::clone(log_buffer));
+
+    loop {
+        // Update state from watch channel
+        if state_rx.has_changed().unwrap_or(false) {
+            app.update_state(state_rx.borrow_and_update().clone());
+        }
+
+        terminal.draw(|frame| ui::draw(frame, &app))?;
+
+        // Poll for events with a short timeout so we can re-render on state changes
+        if event::poll(std::time::Duration::from_millis(33))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press {
+                    let action = app.handle_key(key);
+                    match action {
+                        app::AppAction::Quit => {
+                            let _ = cmd_tx.send(UiCommand::Quit);
+                            break;
+                        }
+                        app::AppAction::Command(cmd) => {
+                            let _ = cmd_tx.send(cmd);
+                        }
+                        app::AppAction::None => {}
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/voxmux-tui/src/log_layer.rs
+++ b/crates/voxmux-tui/src/log_layer.rs
@@ -1,0 +1,113 @@
+use std::collections::VecDeque;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::Subscriber;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+/// A tracing layer that captures formatted log events into a bounded buffer.
+pub struct TuiLogLayer {
+    buffer: Arc<Mutex<VecDeque<String>>>,
+    capacity: usize,
+}
+
+impl TuiLogLayer {
+    pub fn new(buffer: Arc<Mutex<VecDeque<String>>>, capacity: usize) -> Self {
+        Self { buffer, capacity }
+    }
+}
+
+struct MessageVisitor {
+    message: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{:?}", value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        }
+    }
+}
+
+impl<S: Subscriber> Layer<S> for TuiLogLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let level = metadata.level();
+        let target = metadata.target();
+
+        let mut visitor = MessageVisitor {
+            message: String::new(),
+        };
+        event.record(&mut visitor);
+
+        let formatted = format!("[{}] {}: {}", level, target, visitor.message);
+
+        if let Ok(mut buf) = self.buffer.lock() {
+            if buf.len() >= self.capacity {
+                buf.pop_front();
+            }
+            buf.push_back(formatted);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Registry;
+
+    fn make_layer_and_buffer(
+        capacity: usize,
+    ) -> (Arc<Mutex<VecDeque<String>>>, impl tracing::Subscriber) {
+        let buffer = Arc::new(Mutex::new(VecDeque::new()));
+        let layer = TuiLogLayer::new(Arc::clone(&buffer), capacity);
+        let subscriber = Registry::default().with(layer);
+        (buffer, subscriber)
+    }
+
+    #[test]
+    fn test_log_layer_captures_events() {
+        let (buffer, subscriber) = make_layer_and_buffer(100);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("one");
+            tracing::warn!("two");
+            tracing::error!("three");
+        });
+        let buf = buffer.lock().unwrap();
+        assert_eq!(buf.len(), 3);
+    }
+
+    #[test]
+    fn test_log_layer_bounded_drops_oldest() {
+        let (buffer, subscriber) = make_layer_and_buffer(2);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("first");
+            tracing::info!("second");
+            tracing::info!("third");
+        });
+        let buf = buffer.lock().unwrap();
+        assert_eq!(buf.len(), 2);
+        assert!(buf[0].contains("second"), "expected 'second', got: {}", buf[0]);
+        assert!(buf[1].contains("third"), "expected 'third', got: {}", buf[1]);
+    }
+
+    #[test]
+    fn test_log_layer_format() {
+        let (buffer, subscriber) = make_layer_and_buffer(100);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "voxmux", "hello");
+        });
+        let buf = buffer.lock().unwrap();
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf[0], "[INFO] voxmux: hello");
+    }
+}

--- a/crates/voxmux-tui/src/ui.rs
+++ b/crates/voxmux-tui/src/ui.rs
@@ -1,0 +1,302 @@
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Gauge, List, ListItem, Paragraph, Tabs};
+use ratatui::Frame;
+
+use crate::app::{App, Tab};
+
+pub fn draw(frame: &mut Frame, app: &App) {
+    let [tabs_area, main_area] =
+        Layout::vertical([Constraint::Length(3), Constraint::Fill(1)]).areas(frame.area());
+
+    draw_tabs(frame, app, tabs_area);
+
+    match app.tab {
+        Tab::Dashboard => draw_dashboard(frame, app, main_area),
+        Tab::Inputs => draw_inputs(frame, app, main_area),
+        Tab::Outputs => draw_outputs(frame, app, main_area),
+        Tab::Logs => draw_logs(frame, app, main_area),
+    }
+}
+
+fn draw_tabs(frame: &mut Frame, app: &App, area: Rect) {
+    let titles = vec!["1:Dashboard", "2:Inputs", "3:Outputs", "4:Logs"];
+    let selected = match app.tab {
+        Tab::Dashboard => 0,
+        Tab::Inputs => 1,
+        Tab::Outputs => 2,
+        Tab::Logs => 3,
+    };
+    let tabs = Tabs::new(titles)
+        .block(Block::default().borders(Borders::ALL).title("voxmux"))
+        .select(selected)
+        .highlight_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+    frame.render_widget(tabs, area);
+}
+
+fn draw_dashboard(frame: &mut Frame, app: &App, area: Rect) {
+    if app.state.inputs.is_empty() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title("Dashboard");
+        let para = Paragraph::new("No inputs configured").block(block);
+        frame.render_widget(para, area);
+        return;
+    }
+
+    let constraints: Vec<Constraint> = app
+        .state
+        .inputs
+        .iter()
+        .map(|_| Constraint::Length(2))
+        .chain(std::iter::once(Constraint::Fill(1)))
+        .collect();
+
+    let areas = Layout::vertical(constraints).split(area);
+
+    for (i, input) in app.state.inputs.iter().enumerate() {
+        let label = format!(
+            "{} {}",
+            input.id,
+            if input.muted { "[M]" } else { "" }
+        );
+        let ratio = input.peak_level.clamp(0.0, 1.0) as f64;
+        let gauge = Gauge::default()
+            .block(Block::default().title(label))
+            .gauge_style(Style::default().fg(if input.muted { Color::DarkGray } else { Color::Green }))
+            .ratio(ratio);
+        frame.render_widget(gauge, areas[i]);
+    }
+
+    // Remaining area: recent recognitions
+    let last = areas.len() - 1;
+    let recog_items: Vec<ListItem> = app
+        .state
+        .latest_recognitions
+        .iter()
+        .rev()
+        .take(10)
+        .map(|s| ListItem::new(s.as_str()))
+        .collect();
+    let recog_list = List::new(recog_items)
+        .block(Block::default().borders(Borders::ALL).title("Recent ASR"));
+    frame.render_widget(recog_list, areas[last]);
+}
+
+fn draw_inputs(frame: &mut Frame, app: &App, area: Rect) {
+    let items: Vec<ListItem> = app
+        .state
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| {
+            let marker = if i == app.selected_input { ">" } else { " " };
+            let mute_str = if input.muted { " [MUTED]" } else { "" };
+            let enabled_str = if input.enabled { "" } else { " (disabled)" };
+            let line = Line::from(vec![
+                Span::raw(format!("{} ", marker)),
+                Span::styled(
+                    &input.device_name,
+                    if i == app.selected_input {
+                        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    },
+                ),
+                Span::raw(format!(
+                    "  vol:{:.0}%{}{}",
+                    input.volume * 100.0,
+                    mute_str,
+                    enabled_str,
+                )),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Inputs (Up/Down=select, Left/Right=vol, m=mute, e=enable)"),
+    );
+    frame.render_widget(list, area);
+}
+
+fn draw_outputs(frame: &mut Frame, app: &App, area: Rect) {
+    let play_str = if app.state.output.play_mixed_input {
+        "ON"
+    } else {
+        "OFF"
+    };
+    let text = format!(
+        "Output device: {}\nPlay mixed input: {} (Space to toggle)",
+        app.state.output.device_name, play_str,
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title("Output");
+    let para = Paragraph::new(text).block(block);
+    frame.render_widget(para, area);
+}
+
+fn draw_logs(frame: &mut Frame, app: &App, area: Rect) {
+    let logs = app.logs.lock().unwrap();
+    let total = logs.len();
+
+    let visible_height = area.height.saturating_sub(2) as usize; // account for borders
+    let scroll = app.log_scroll.min(total.saturating_sub(visible_height));
+    let end = total.saturating_sub(scroll);
+    let start = end.saturating_sub(visible_height);
+
+    let items: Vec<ListItem> = logs
+        .iter()
+        .skip(start)
+        .take(end - start)
+        .map(|s| ListItem::new(s.as_str()))
+        .collect();
+
+    let title = if app.log_auto_scroll {
+        "Logs (auto-scroll)"
+    } else {
+        "Logs (Up/Down=scroll, G=bottom)"
+    };
+    let list = List::new(items).block(Block::default().borders(Borders::ALL).title(title));
+    frame.render_widget(list, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+    use ratatui::buffer::Buffer;
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+    use voxmux_core::tui_types::{InputState, RouterState};
+
+    fn buffer_text(buf: &Buffer) -> String {
+        let area = buf.area();
+        let mut text = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                text.push_str(buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+            }
+            text.push('\n');
+        }
+        text
+    }
+
+    #[test]
+    fn test_dashboard_renders_vu_meters() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new(Arc::new(Mutex::new(VecDeque::new())));
+        app.update_state(RouterState {
+            inputs: vec![
+                InputState {
+                    id: "mic1".into(),
+                    device_name: "USB Mic".into(),
+                    enabled: true,
+                    volume: 0.8,
+                    muted: false,
+                    peak_level: 0.6,
+                },
+                InputState {
+                    id: "mic2".into(),
+                    device_name: "Line In".into(),
+                    enabled: true,
+                    volume: 0.5,
+                    muted: false,
+                    peak_level: 0.3,
+                },
+            ],
+            ..Default::default()
+        });
+        app.tab = Tab::Dashboard;
+
+        terminal
+            .draw(|frame| draw(frame, &app))
+            .unwrap();
+
+        let text = buffer_text(terminal.backend().buffer());
+        // Gauge renders block chars for the filled portion
+        assert!(
+            text.contains("mic1") && text.contains("mic2"),
+            "expected both input ids in dashboard, got:\n{}",
+            text,
+        );
+    }
+
+    #[test]
+    fn test_inputs_tab_renders_device_list() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new(Arc::new(Mutex::new(VecDeque::new())));
+        app.update_state(RouterState {
+            inputs: vec![
+                InputState {
+                    id: "a".into(),
+                    device_name: "DeviceAlpha".into(),
+                    ..Default::default()
+                },
+                InputState {
+                    id: "b".into(),
+                    device_name: "DeviceBeta".into(),
+                    ..Default::default()
+                },
+                InputState {
+                    id: "c".into(),
+                    device_name: "DeviceGamma".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        });
+        app.tab = Tab::Inputs;
+
+        terminal
+            .draw(|frame| draw(frame, &app))
+            .unwrap();
+
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("DeviceAlpha"), "missing DeviceAlpha:\n{}", text);
+        assert!(text.contains("DeviceBeta"), "missing DeviceBeta:\n{}", text);
+        assert!(text.contains("DeviceGamma"), "missing DeviceGamma:\n{}", text);
+    }
+
+    #[test]
+    fn test_logs_tab_renders_log_lines() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let logs = Arc::new(Mutex::new(VecDeque::new()));
+        {
+            let mut buf = logs.lock().unwrap();
+            for i in 0..10 {
+                buf.push_back(format!("[INFO] test: log message {}", i));
+            }
+        }
+
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new(Arc::clone(&logs));
+        app.tab = Tab::Logs;
+
+        terminal
+            .draw(|frame| draw(frame, &app))
+            .unwrap();
+
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(
+            text.contains("log message"),
+            "expected log text in output:\n{}",
+            text,
+        );
+    }
+}

--- a/crates/voxmux-tui/tests/integration.rs
+++ b/crates/voxmux-tui/tests/integration.rs
@@ -1,0 +1,101 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+use voxmux_core::tui_types::{InputState, OutputState, RouterState};
+use voxmux_tui::app::{App, Tab};
+use voxmux_tui::ui;
+
+fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+    let area = buf.area();
+    let mut text = String::new();
+    for y in area.y..area.y + area.height {
+        for x in area.x..area.x + area.width {
+            text.push_str(buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+        }
+        text.push('\n');
+    }
+    text
+}
+
+#[test]
+fn test_full_draw_cycle() {
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let logs = Arc::new(Mutex::new(VecDeque::new()));
+    {
+        let mut buf = logs.lock().unwrap();
+        buf.push_back("[INFO] test: startup".to_string());
+    }
+
+    let mut app = App::new(Arc::clone(&logs));
+    app.update_state(RouterState {
+        inputs: vec![InputState {
+            id: "mic1".into(),
+            device_name: "Test Mic".into(),
+            enabled: true,
+            volume: 0.75,
+            muted: false,
+            peak_level: 0.4,
+        }],
+        output: OutputState {
+            device_name: "Test Speakers".into(),
+            play_mixed_input: true,
+        },
+        latest_recognitions: vec!["hello world".to_string()],
+        is_running: true,
+    });
+
+    // Draw all 4 tabs — no panics
+    for tab in &[Tab::Dashboard, Tab::Inputs, Tab::Outputs, Tab::Logs] {
+        app.tab = *tab;
+        terminal
+            .draw(|frame| ui::draw(frame, &app))
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_state_watch_updates_render() {
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut app = App::new(Arc::new(Mutex::new(VecDeque::new())));
+    app.tab = Tab::Inputs;
+
+    // Initial render: no inputs
+    terminal
+        .draw(|frame| ui::draw(frame, &app))
+        .unwrap();
+    let text = buffer_text(terminal.backend().buffer());
+    assert!(!text.contains("NewDevice"), "should not contain NewDevice yet");
+
+    // Simulate watch update: add 2 inputs
+    app.update_state(RouterState {
+        inputs: vec![
+            InputState {
+                id: "new1".into(),
+                device_name: "NewDevice1".into(),
+                enabled: true,
+                volume: 0.5,
+                ..Default::default()
+            },
+            InputState {
+                id: "new2".into(),
+                device_name: "NewDevice2".into(),
+                enabled: true,
+                volume: 0.8,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    });
+
+    // Re-render should show updated inputs
+    terminal
+        .draw(|frame| ui::draw(frame, &app))
+        .unwrap();
+    let text = buffer_text(terminal.backend().buffer());
+    assert!(text.contains("NewDevice1"), "expected NewDevice1:\n{}", text);
+    assert!(text.contains("NewDevice2"), "expected NewDevice2:\n{}", text);
+}


### PR DESCRIPTION
## Summary
- Add 4-tab ratatui terminal UI (Dashboard, Inputs, Outputs, Logs) with crossterm key handling
- Implement `watch`/`mpsc` channel architecture for decoupled TUI↔engine communication (state broadcast ~30Hz, UI commands)
- Add `TuiLogLayer` custom tracing layer capturing events into bounded log buffer for Logs tab
- Add shared types (`RouterState`, `InputState`, `OutputState`, `UiCommand`) in voxmux-core so the TUI crate has zero dependency on audio/engine/destination crates
- Wire into `main.rs`: layered tracing subscriber, state broadcast task, command handler task

## Test plan
- [x] `cargo test -p voxmux-core` — 19 tests pass (4 new tui_types tests)
- [x] `cargo test -p voxmux-tui` — 20 tests pass (18 unit + 2 integration)
- [x] `cargo test --workspace` — 131 pass, 1 ignored (no regressions)
- [x] `cargo build --workspace` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)