### PR TITLE
Add Phase 6: Polish — peak levels, handles, health, config reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +447,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-core"
@@ -528,6 +548,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +578,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -604,6 +653,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +692,17 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "redox_syscall 0.7.1",
 ]
 
 [[package]]
@@ -737,6 +817,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,7 +948,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -937,6 +1045,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -1441,6 +1558,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "notify",
  "tokio",
  "toml",
  "tracing",
@@ -1467,6 +1585,7 @@ dependencies = [
 name = "voxmux-core"
 version = "0.1.0"
 dependencies = [
+ "notify",
  "regex",
  "serde",
  "thiserror 2.0.18",
@@ -1681,6 +1800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ regex = "1"
 async-trait = "0.1"
 ratatui = "0.29"
 crossterm = "0.28"
+notify = "7"
 
 # Internal crates
 voxmux-core = { path = "crates/voxmux-core" }
@@ -50,3 +51,4 @@ tracing-subscriber = { workspace = true }
 toml = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+notify = { workspace = true }

--- a/crates/voxmux-audio/src/capture.rs
+++ b/crates/voxmux-audio/src/capture.rs
@@ -3,8 +3,52 @@ use cpal::traits::DeviceTrait;
 use cpal::{Device, SampleRate, Stream, StreamConfig};
 use ringbuf::traits::Producer;
 use ringbuf::HeapProd;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
+use voxmux_core::InputStatus;
+
+// ── CaptureHandle ─────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct CaptureHandle {
+    enabled: Arc<AtomicBool>,
+    status: Arc<AtomicU8>,
+    id: String,
+}
+
+impl CaptureHandle {
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub fn set_enabled(&self, v: bool) {
+        self.enabled.store(v, Ordering::Relaxed);
+    }
+
+    pub fn status(&self) -> InputStatus {
+        match self.status.load(Ordering::Relaxed) {
+            1 => InputStatus::Error,
+            2 => InputStatus::Disabled,
+            _ => InputStatus::Ok,
+        }
+    }
+
+    pub fn set_status(&self, s: InputStatus) {
+        let v = match s {
+            InputStatus::Ok => 0,
+            InputStatus::Error => 1,
+            InputStatus::Disabled => 2,
+        };
+        self.status.store(v, Ordering::Relaxed);
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+// ── CaptureNode ───────────────────────────────────────────────
 
 pub struct CaptureNode {
     _stream: Stream,
@@ -18,7 +62,8 @@ impl CaptureNode {
         channels: u16,
         buffer_size: u32,
         asr_tap: Option<mpsc::UnboundedSender<AudioChunk>>,
-    ) -> Result<Self, AudioError> {
+        id: &str,
+    ) -> Result<(Self, CaptureHandle), AudioError> {
         let config = StreamConfig {
             channels,
             sample_rate: SampleRate(sample_rate),
@@ -26,15 +71,23 @@ impl CaptureNode {
         };
 
         let producer = Arc::new(Mutex::new(producer));
+        let enabled = Arc::new(AtomicBool::new(true));
+        let enabled_flag = Arc::clone(&enabled);
+        let status = Arc::new(AtomicU8::new(0));
+        let status_flag = Arc::clone(&status);
 
-        let err_callback = |err: cpal::StreamError| {
+        let err_callback = move |err: cpal::StreamError| {
             tracing::error!("capture stream error: {}", err);
+            status_flag.store(1, Ordering::Relaxed); // Error
         };
 
         let stream = device
             .build_input_stream(
                 &config,
                 move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                    if !enabled_flag.load(Ordering::Relaxed) {
+                        return;
+                    }
                     if let Ok(mut prod) = producer.lock() {
                         // Push as much as we can; overflow is silently dropped
                         prod.push_slice(data);
@@ -53,14 +106,66 @@ impl CaptureNode {
             )
             .map_err(|e| AudioError::StreamBuild(e.to_string()))?;
 
-        Ok(Self { _stream: stream })
+        let handle = CaptureHandle {
+            enabled,
+            status,
+            id: id.to_string(),
+        };
+        Ok((Self { _stream: stream }, handle))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use voxmux_core::AudioChunk;
     use tokio::sync::mpsc;
+
+    fn make_capture_handle(id: &str) -> CaptureHandle {
+        CaptureHandle {
+            enabled: Arc::new(AtomicBool::new(true)),
+            status: Arc::new(AtomicU8::new(0)),
+            id: id.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_capture_handle_default_enabled() {
+        let handle = make_capture_handle("mic1");
+        assert!(handle.is_enabled());
+    }
+
+    #[test]
+    fn test_capture_handle_disable() {
+        let handle = make_capture_handle("mic1");
+        handle.set_enabled(false);
+        assert!(!handle.is_enabled());
+        handle.set_enabled(true);
+        assert!(handle.is_enabled());
+    }
+
+    #[test]
+    fn test_capture_handle_clone_shares_state() {
+        let h1 = make_capture_handle("mic1");
+        let h2 = h1.clone();
+        h1.set_enabled(false);
+        assert!(!h2.is_enabled());
+    }
+
+    #[test]
+    fn test_capture_handle_status_default_ok() {
+        let handle = make_capture_handle("mic1");
+        assert_eq!(handle.status(), InputStatus::Ok);
+    }
+
+    #[test]
+    fn test_capture_handle_set_error_status() {
+        let handle = make_capture_handle("mic1");
+        handle.set_status(InputStatus::Error);
+        assert_eq!(handle.status(), InputStatus::Error);
+        handle.set_status(InputStatus::Ok);
+        assert_eq!(handle.status(), InputStatus::Ok);
+    }
 
     #[test]
     fn test_asr_tap_send_receives_chunk() {

--- a/crates/voxmux-audio/src/lib.rs
+++ b/crates/voxmux-audio/src/lib.rs
@@ -3,10 +3,10 @@ pub mod device;
 pub mod mixer;
 pub mod output;
 
-pub use capture::CaptureNode;
+pub use capture::{CaptureHandle, CaptureNode};
 pub use device::DeviceManager;
 pub use mixer::{InputHandle, Mixer, MixerHandle};
-pub use output::OutputNode;
+pub use output::{OutputHandle, OutputNode};
 
 use ringbuf::traits::Split;
 use ringbuf::{HeapCons, HeapProd, HeapRb};

--- a/crates/voxmux-audio/src/output.rs
+++ b/crates/voxmux-audio/src/output.rs
@@ -3,7 +3,36 @@ use cpal::traits::DeviceTrait;
 use cpal::{Device, SampleRate, Stream, StreamConfig};
 use ringbuf::traits::Consumer;
 use ringbuf::HeapCons;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
+use voxmux_core::InputStatus;
+
+// ── OutputHandle ──────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct OutputHandle {
+    playing: Arc<AtomicBool>,
+    status: Arc<AtomicU8>,
+}
+
+impl OutputHandle {
+    pub fn is_playing(&self) -> bool {
+        self.playing.load(Ordering::Relaxed)
+    }
+
+    pub fn set_playing(&self, v: bool) {
+        self.playing.store(v, Ordering::Relaxed);
+    }
+
+    pub fn status(&self) -> InputStatus {
+        match self.status.load(Ordering::Relaxed) {
+            1 => InputStatus::Error,
+            _ => InputStatus::Ok,
+        }
+    }
+}
+
+// ── OutputNode ────────────────────────────────────────────────
 
 pub struct OutputNode {
     _stream: Stream,
@@ -16,7 +45,7 @@ impl OutputNode {
         sample_rate: u32,
         channels: u16,
         buffer_size: u32,
-    ) -> Result<Self, AudioError> {
+    ) -> Result<(Self, OutputHandle), AudioError> {
         let config = StreamConfig {
             channels,
             sample_rate: SampleRate(sample_rate),
@@ -24,15 +53,24 @@ impl OutputNode {
         };
 
         let consumer = Arc::new(Mutex::new(consumer));
+        let playing = Arc::new(AtomicBool::new(true));
+        let playing_flag = Arc::clone(&playing);
+        let status = Arc::new(AtomicU8::new(0));
+        let status_flag = Arc::clone(&status);
 
-        let err_callback = |err: cpal::StreamError| {
+        let err_callback = move |err: cpal::StreamError| {
             tracing::error!("output stream error: {}", err);
+            status_flag.store(1, Ordering::Relaxed); // Error
         };
 
         let stream = device
             .build_output_stream(
                 &config,
                 move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                    if !playing_flag.load(Ordering::Relaxed) {
+                        data.fill(0.0);
+                        return;
+                    }
                     if let Ok(mut cons) = consumer.lock() {
                         for sample in data.iter_mut() {
                             *sample = cons.try_pop().unwrap_or(0.0);
@@ -47,6 +85,48 @@ impl OutputNode {
             )
             .map_err(|e| AudioError::StreamBuild(e.to_string()))?;
 
-        Ok(Self { _stream: stream })
+        let handle = OutputHandle { playing, status };
+        Ok((Self { _stream: stream }, handle))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_output_handle() -> OutputHandle {
+        OutputHandle {
+            playing: Arc::new(AtomicBool::new(true)),
+            status: Arc::new(AtomicU8::new(0)),
+        }
+    }
+
+    #[test]
+    fn test_output_handle_default_playing() {
+        let handle = make_output_handle();
+        assert!(handle.is_playing());
+    }
+
+    #[test]
+    fn test_output_handle_set_playing() {
+        let handle = make_output_handle();
+        handle.set_playing(false);
+        assert!(!handle.is_playing());
+        handle.set_playing(true);
+        assert!(handle.is_playing());
+    }
+
+    #[test]
+    fn test_output_handle_clone_shares_state() {
+        let h1 = make_output_handle();
+        let h2 = h1.clone();
+        h1.set_playing(false);
+        assert!(!h2.is_playing());
+    }
+
+    #[test]
+    fn test_output_handle_status_default_ok() {
+        let handle = make_output_handle();
+        assert_eq!(handle.status(), InputStatus::Ok);
     }
 }

--- a/crates/voxmux-core/Cargo.toml
+++ b/crates/voxmux-core/Cargo.toml
@@ -9,3 +9,4 @@ toml = { workspace = true }
 thiserror = { workspace = true }
 regex = { workspace = true }
 tracing = { workspace = true }
+notify = { workspace = true }

--- a/crates/voxmux-core/src/config_diff.rs
+++ b/crates/voxmux-core/src/config_diff.rs
@@ -1,0 +1,210 @@
+use crate::config::AppConfig;
+
+/// Describes runtime-safe changes between two configs.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ConfigDiff {
+    pub volume_changes: Vec<(String, f32)>,
+    pub mute_changes: Vec<(String, bool)>,
+    pub play_mixed_change: Option<bool>,
+    pub non_reloadable: Vec<String>,
+}
+
+impl ConfigDiff {
+    /// Compare two configs and return the diff.
+    /// Reloadable: volume, mute, play_mixed_input.
+    /// Non-reloadable: device changes, sample_rate, buffer_size, ASR engine — logged as warnings.
+    pub fn diff(old: &AppConfig, new: &AppConfig) -> Self {
+        let mut result = Self::default();
+
+        // Check non-reloadable general settings
+        if old.general.sample_rate != new.general.sample_rate {
+            result.non_reloadable.push(format!(
+                "sample_rate changed ({} → {}), requires restart",
+                old.general.sample_rate, new.general.sample_rate
+            ));
+        }
+        if old.general.buffer_size != new.general.buffer_size {
+            result.non_reloadable.push(format!(
+                "buffer_size changed ({} → {}), requires restart",
+                old.general.buffer_size, new.general.buffer_size
+            ));
+        }
+
+        // Check output device change (non-reloadable)
+        if old.output.device_name != new.output.device_name {
+            result.non_reloadable.push(format!(
+                "output device changed ('{}' → '{}'), requires restart",
+                old.output.device_name, new.output.device_name
+            ));
+        }
+
+        // Check play_mixed_input (reloadable)
+        if old.output.play_mixed_input != new.output.play_mixed_input {
+            result.play_mixed_change = Some(new.output.play_mixed_input);
+        }
+
+        // Check per-input changes
+        for new_input in &new.input {
+            if let Some(old_input) = old.input.iter().find(|i| i.id == new_input.id) {
+                // Volume change (reloadable)
+                if (old_input.volume - new_input.volume).abs() > f32::EPSILON {
+                    result
+                        .volume_changes
+                        .push((new_input.id.clone(), new_input.volume));
+                }
+                // Mute change (reloadable)
+                if old_input.muted != new_input.muted {
+                    result
+                        .mute_changes
+                        .push((new_input.id.clone(), new_input.muted));
+                }
+                // Device name change (non-reloadable)
+                if old_input.device_name != new_input.device_name {
+                    result.non_reloadable.push(format!(
+                        "input '{}' device changed ('{}' → '{}'), requires restart",
+                        new_input.id, old_input.device_name, new_input.device_name
+                    ));
+                }
+            }
+        }
+
+        // Check ASR engine change (non-reloadable)
+        match (&old.asr, &new.asr) {
+            (Some(old_asr), Some(new_asr)) if old_asr.engine != new_asr.engine => {
+                result.non_reloadable.push(format!(
+                    "ASR engine changed ('{}' → '{}'), requires restart",
+                    old_asr.engine, new_asr.engine
+                ));
+            }
+            _ => {}
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_config() -> AppConfig {
+        AppConfig::from_toml_str(
+            r#"
+[output]
+device_name = "speakers"
+play_mixed_input = true
+
+[[input]]
+id = "mic1"
+device_name = "USB Mic"
+volume = 0.8
+muted = false
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_config_diff_volume_change() {
+        let old = base_config();
+        let new = AppConfig::from_toml_str(
+            r#"
+[output]
+device_name = "speakers"
+play_mixed_input = true
+
+[[input]]
+id = "mic1"
+device_name = "USB Mic"
+volume = 0.5
+muted = false
+"#,
+        )
+        .unwrap();
+
+        let diff = ConfigDiff::diff(&old, &new);
+        assert_eq!(diff.volume_changes, vec![("mic1".to_string(), 0.5)]);
+        assert!(diff.mute_changes.is_empty());
+        assert!(diff.non_reloadable.is_empty());
+    }
+
+    #[test]
+    fn test_config_diff_mute_change() {
+        let old = base_config();
+        let new = AppConfig::from_toml_str(
+            r#"
+[output]
+device_name = "speakers"
+play_mixed_input = true
+
+[[input]]
+id = "mic1"
+device_name = "USB Mic"
+volume = 0.8
+muted = true
+"#,
+        )
+        .unwrap();
+
+        let diff = ConfigDiff::diff(&old, &new);
+        assert!(diff.volume_changes.is_empty());
+        assert_eq!(diff.mute_changes, vec![("mic1".to_string(), true)]);
+    }
+
+    #[test]
+    fn test_config_diff_no_change() {
+        let old = base_config();
+        let new = base_config();
+        let diff = ConfigDiff::diff(&old, &new);
+        assert!(diff.volume_changes.is_empty());
+        assert!(diff.mute_changes.is_empty());
+        assert!(diff.play_mixed_change.is_none());
+        assert!(diff.non_reloadable.is_empty());
+    }
+
+    #[test]
+    fn test_config_diff_ignores_device_change() {
+        let old = base_config();
+        let new = AppConfig::from_toml_str(
+            r#"
+[output]
+device_name = "speakers"
+play_mixed_input = true
+
+[[input]]
+id = "mic1"
+device_name = "New Device"
+volume = 0.8
+muted = false
+"#,
+        )
+        .unwrap();
+
+        let diff = ConfigDiff::diff(&old, &new);
+        assert!(diff.volume_changes.is_empty());
+        assert_eq!(diff.non_reloadable.len(), 1);
+        assert!(diff.non_reloadable[0].contains("device changed"));
+    }
+
+    #[test]
+    fn test_config_diff_play_mixed_change() {
+        let old = base_config();
+        let new = AppConfig::from_toml_str(
+            r#"
+[output]
+device_name = "speakers"
+play_mixed_input = false
+
+[[input]]
+id = "mic1"
+device_name = "USB Mic"
+volume = 0.8
+muted = false
+"#,
+        )
+        .unwrap();
+
+        let diff = ConfigDiff::diff(&old, &new);
+        assert_eq!(diff.play_mixed_change, Some(false));
+    }
+}

--- a/crates/voxmux-core/src/lib.rs
+++ b/crates/voxmux-core/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod config;
+pub mod config_diff;
 pub mod error;
 pub mod tui_types;
 pub mod types;
 
 pub use config::AppConfig;
+pub use config_diff::ConfigDiff;
 pub use error::{AsrError, AudioError, ConfigError, DestinationError};
-pub use tui_types::{InputState, OutputState, RouterState, UiCommand};
+pub use tui_types::{InputState, InputStatus, OutputState, RouterState, UiCommand};
 pub use types::{AudioChunk, RecognitionResult, TextMetadata};
 
 #[cfg(test)]

--- a/crates/voxmux-core/src/tui_types.rs
+++ b/crates/voxmux-core/src/tui_types.rs
@@ -1,3 +1,12 @@
+/// Health status for an input or output device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InputStatus {
+    #[default]
+    Ok,
+    Error,
+    Disabled,
+}
+
 /// State of a single audio input, for TUI display.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct InputState {
@@ -7,6 +16,7 @@ pub struct InputState {
     pub volume: f32,
     pub muted: bool,
     pub peak_level: f32,
+    pub status: InputStatus,
 }
 
 /// State of the audio output, for TUI display.
@@ -31,6 +41,7 @@ pub struct RouterState {
     pub inputs: Vec<InputState>,
     pub output: OutputState,
     pub latest_recognitions: Vec<String>,
+    pub warnings: Vec<String>,
     pub is_running: bool,
 }
 
@@ -66,6 +77,24 @@ mod tests {
         assert_eq!(input.peak_level, 0.0);
         assert!(input.id.is_empty());
         assert!(input.device_name.is_empty());
+        assert_eq!(input.status, InputStatus::Ok);
+    }
+
+    #[test]
+    fn test_input_status_default_ok() {
+        assert_eq!(InputStatus::default(), InputStatus::Ok);
+    }
+
+    #[test]
+    fn test_input_state_has_status() {
+        let input = InputState::default();
+        assert_eq!(input.status, InputStatus::Ok);
+    }
+
+    #[test]
+    fn test_router_state_has_warnings() {
+        let state = RouterState::default();
+        assert!(state.warnings.is_empty());
     }
 
     #[test]
@@ -88,12 +117,14 @@ mod tests {
                 volume: 0.8,
                 muted: false,
                 peak_level: 0.5,
+                status: InputStatus::Ok,
             }],
             output: OutputState {
                 device_name: "speakers".to_string(),
                 play_mixed_input: true,
             },
             latest_recognitions: vec!["hello".to_string()],
+            warnings: Vec::new(),
             is_running: true,
         };
         let cloned = state.clone();

--- a/crates/voxmux-tui/tests/integration.rs
+++ b/crates/voxmux-tui/tests/integration.rs
@@ -38,13 +38,14 @@ fn test_full_draw_cycle() {
             volume: 0.75,
             muted: false,
             peak_level: 0.4,
+            ..Default::default()
         }],
         output: OutputState {
             device_name: "Test Speakers".into(),
             play_mixed_input: true,
         },
         latest_recognitions: vec!["hello world".to_string()],
-        is_running: true,
+        ..Default::default()
     });
 
     // Draw all 4 tabs — no panics


### PR DESCRIPTION
## Summary
- **Peak level tracking**: Atomic `peak_bits` in `InputControls`, computed post-gain in `mix_once()` with 0.85 decay — VU meters now work
- **OutputHandle / CaptureHandle**: New handle types returned from `OutputNode::new()` / `CaptureNode::new()` with atomic playing/enabled state and health status — `SetPlayMixedInput` and `SetEnabled` TUI commands now functional
- **Health/Status tracking**: `InputStatus` enum (Ok/Error/Disabled), cpal error callbacks set Error status, dashboard renders warnings panel
- **ASR results forwarding**: Bounded recognition buffer (cap 50), forwarder task copies to buffer + forwards to DestinationHost, dashboard "Recent ASR" panel populated
- **Config hot-reload**: `ConfigDiff::diff()` detects reloadable vs non-reloadable changes, `notify` filesystem watcher applies volume/mute/enabled/play changes at runtime
- **main.rs fully wired**: All P5 no-ops resolved, state broadcast reads peak/status/warnings/recognitions

## Test plan
- [x] `cargo test --workspace` — 161 pass, 1 ignored (30 new tests)
- [x] `cargo build --workspace` — clean, no warnings
- [ ] Manual: verify VU meters animate in TUI dashboard
- [ ] Manual: verify config file edit triggers hot-reload
- [ ] Manual: verify `e` key toggles input enabled/disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)